### PR TITLE
Add SQLite-based person management

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
@@ -1,0 +1,64 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AppDatabaseHelper extends SQLiteOpenHelper {
+
+    private static final String DATABASE_NAME = "app.db";
+    private static final int DATABASE_VERSION = 1;
+
+    public static final String TABLE_PERSONS = "persons";
+    public static final String COLUMN_ID = "id";
+    public static final String COLUMN_NAME = "name";
+
+    public static final String TABLE_PURCHASES = "purchases";
+
+    public AppDatabaseHelper(Context context) {
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        String createPersons = "CREATE TABLE " + TABLE_PERSONS + " (" +
+                COLUMN_ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                COLUMN_NAME + " TEXT NOT NULL)";
+        db.execSQL(createPersons);
+
+        String createPurchases = "CREATE TABLE " + TABLE_PURCHASES + " (id INTEGER PRIMARY KEY AUTOINCREMENT)";
+        db.execSQL(createPurchases);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_PERSONS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_PURCHASES);
+        onCreate(db);
+    }
+
+    public long addPerson(String name) {
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_NAME, name);
+        return db.insert(TABLE_PERSONS, null, values);
+    }
+
+    public List<Person> getAllPersons() {
+        List<Person> people = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.query(TABLE_PERSONS, null, null, null, null, null, null);
+        while (cursor.moveToNext()) {
+            long id = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_ID));
+            String name = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_NAME));
+            people.add(new Person(id, name));
+        }
+        cursor.close();
+        return people;
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Person.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Person.java
@@ -1,10 +1,20 @@
 package de.th.nuernberg.bme.lidlsplit;
 
 public class Person {
+    private final long id;
     private final String name;
 
-    public Person(String name) {
+    public Person(long id, String name) {
+        this.id = id;
         this.name = name;
+    }
+
+    public Person(String name) {
+        this(-1, name);
+    }
+
+    public long getId() {
+        return id;
     }
 
     public String getName() {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonAdapter.java
@@ -20,6 +20,17 @@ public class PersonAdapter extends RecyclerView.Adapter<PersonAdapter.PersonView
         this.people = people;
     }
 
+    public void addPerson(Person person) {
+        people.add(person);
+        notifyItemInserted(people.size() - 1);
+    }
+
+    public void updateData(List<Person> newPeople) {
+        people.clear();
+        people.addAll(newPeople);
+        notifyDataSetChanged();
+    }
+
     @NonNull
     @Override
     public PersonViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
@@ -1,8 +1,12 @@
 package de.th.nuernberg.bme.lidlsplit;
 
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -12,29 +16,30 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import java.util.ArrayList;
-import java.util.List;
 
 public class PersonsActivity extends AppCompatActivity {
 
     private TextView navPurchases;
     private TextView navPeople;
+    private PersonAdapter adapter;
+    private AppDatabaseHelper dbHelper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_persons);
 
+        dbHelper = new AppDatabaseHelper(this);
+
         // RecyclerView
         RecyclerView recyclerView = findViewById(R.id.recyclerPersons);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        PersonAdapter adapter = new PersonAdapter(createDummyPersons());
+        adapter = new PersonAdapter(dbHelper.getAllPersons());
         recyclerView.setAdapter(adapter);
 
         // Add person button
         Button addButton = findViewById(R.id.btnAddPerson);
-        addButton.setOnClickListener(v ->
-                Toast.makeText(this, "+ Person hinzufügen", Toast.LENGTH_SHORT).show());
+        addButton.setOnClickListener(v -> showAddPersonDialog());
 
         // Filter button
         ImageButton filterButton = findViewById(R.id.btnFilter);
@@ -57,16 +62,34 @@ public class PersonsActivity extends AppCompatActivity {
         navPeople.setOnClickListener(v -> activateTab(navPeople, navPurchases));
     }
 
+    private void showAddPersonDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        View view = LayoutInflater.from(this).inflate(R.layout.dialog_add_person, null);
+        EditText etName = view.findViewById(R.id.etPersonName);
+        builder.setView(view)
+                .setTitle(R.string.dialog_add_person_title)
+                .setNegativeButton(R.string.action_cancel, null)
+                .setPositiveButton(R.string.action_save, null);
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(d -> {
+            Button save = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+            save.setOnClickListener(v -> {
+                String name = etName.getText().toString().trim();
+                if (name.isEmpty()) {
+                    etName.setError(getString(R.string.hint_person_name));
+                    return;
+                }
+                long id = dbHelper.addPerson(name);
+                adapter.addPerson(new Person(id, name));
+                dialog.dismiss();
+            });
+        });
+        dialog.show();
+    }
+
     private void activateTab(TextView active, TextView inactive) {
         active.setBackgroundColor(ContextCompat.getColor(this, R.color.tab_active));
         inactive.setBackgroundColor(ContextCompat.getColor(this, R.color.tab_inactive));
     }
 
-    private List<Person> createDummyPersons() {
-        List<Person> people = new ArrayList<>();
-        people.add(new Person("Alice"));
-        people.add(new Person("Bob"));
-        people.add(new Person("Charlie"));
-        return people;
-    }
 }

--- a/app/src/main/res/layout/dialog_add_person.xml
+++ b/app/src/main/res/layout/dialog_add_person.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <EditText
+        android:id="@+id/etPersonName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_person_name"
+        android:inputType="textPersonName" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="add_purchase">+ Einkauf hinzufügen</string>
     <string name="add_person">+ Person hinzufügen</string>
     <string name="filter">Filter</string>
+    <string name="dialog_add_person_title">Person hinzufügen</string>
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_save">Speichern</string>
+    <string name="hint_person_name">Name</string>
 </resources>


### PR DESCRIPTION
## Summary
- add DB helper with `persons` table and placeholder `purchases` table
- update `Person` model to contain an `id`
- allow `PersonAdapter` to add or refresh persons
- implement add-person dialog and DB integration in `PersonsActivity`
- add resources for dialog layout and strings

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c265baeac832886e599e80607c996