### PR TITLE
Add slide-in/out animation between activities

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends AppCompatActivity {
         navPeople.setOnClickListener(v -> {
             activateTab(navPeople, navPurchases);
             startActivity(new Intent(this, PersonsActivity.class));
+            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
             finish();
         });
     }

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
@@ -56,6 +56,7 @@ public class PersonsActivity extends AppCompatActivity {
         navPurchases.setOnClickListener(v -> {
             activateTab(navPurchases, navPeople);
             startActivity(new Intent(this, MainActivity.class));
+            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
             finish();
         });
 

--- a/app/src/main/res/anim/slide_in_right.xml
+++ b/app/src/main/res/anim/slide_in_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="100%"
+        android:toXDelta="0%"
+        android:duration="@android:integer/config_mediumAnimTime" />
+</set>

--- a/app/src/main/res/anim/slide_out_left.xml
+++ b/app/src/main/res/anim/slide_out_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0%"
+        android:toXDelta="-100%"
+        android:duration="@android:integer/config_mediumAnimTime" />
+</set>


### PR DESCRIPTION
## Summary
- create slide_in_right and slide_out_left animations
- play slide animation when switching between `MainActivity` and `PersonsActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c2e7fdd188328aece9d3382ba0eb4