### PR TITLE
Fix activity transition animations

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonsActivity.java
@@ -56,7 +56,7 @@ public class PersonsActivity extends AppCompatActivity {
         navPurchases.setOnClickListener(v -> {
             activateTab(navPurchases, navPeople);
             startActivity(new Intent(this, MainActivity.class));
-            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
+            overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right);
             finish();
         });
 

--- a/app/src/main/res/anim/slide_in_left.xml
+++ b/app/src/main/res/anim/slide_in_left.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="-100%"
+        android:toXDelta="0%"
+        android:duration="@android:integer/config_mediumAnimTime" />
+</set>

--- a/app/src/main/res/anim/slide_out_right.xml
+++ b/app/src/main/res/anim/slide_out_right.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:fromXDelta="0%"
+        android:toXDelta="100%"
+        android:duration="@android:integer/config_mediumAnimTime" />
+</set>


### PR DESCRIPTION
## Summary
- add missing slide animation files
- switch transitions in `PersonsActivity` when returning to purchases

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c304a54308328a94416b44c005d87