### PR TITLE
Implement Neuer Einkauf screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.activity)
     implementation(libs.constraintlayout)
+    implementation("com.google.mlkit:text-recognition:16.0.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,10 @@
             android:exported="true"
             android:theme="@style/Theme.LidlSplit" />
 
+        <activity
+            android:name=".NewPurchaseActivity"
+            android:exported="true"
+            android:theme="@style/Theme.LidlSplit" />
 
     </application>
 

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -1,0 +1,138 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.mlkit.vision.common.InputImage;
+import com.google.mlkit.vision.text.TextRecognition;
+import com.google.mlkit.vision.text.TextRecognizer;
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class NewPurchaseActivity extends AppCompatActivity {
+
+    private AppDatabaseHelper dbHelper;
+    private PersonSelectAdapter personAdapter;
+    private ReceiptItemAdapter itemAdapter;
+    private final List<PurchaseItem> items = new ArrayList<>();
+    private final ActivityResultLauncher<String> filePicker = registerForActivityResult(
+            new ActivityResultContracts.GetContent(), this::processImage);
+
+    private TextView navPurchases;
+    private TextView navPeople;
+    private TextView tvResult;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_new_purchase);
+
+        dbHelper = new AppDatabaseHelper(this);
+
+        RecyclerView personRecycler = findViewById(R.id.recyclerPersonsSelect);
+        personRecycler.setLayoutManager(new LinearLayoutManager(this));
+        personAdapter = new PersonSelectAdapter(dbHelper.getAllPersons());
+        personRecycler.setAdapter(personAdapter);
+
+        RecyclerView itemRecycler = findViewById(R.id.recyclerItems);
+        itemRecycler.setLayoutManager(new LinearLayoutManager(this));
+        itemAdapter = new ReceiptItemAdapter(items, dbHelper.getAllPersons());
+        itemRecycler.setAdapter(itemAdapter);
+
+        Button upload = findViewById(R.id.btnUploadReceipt);
+        upload.setOnClickListener(v -> filePicker.launch("image/*"));
+
+        Button create = findViewById(R.id.btnCreateInvoice);
+        create.setOnClickListener(v -> createInvoice());
+
+        tvResult = findViewById(R.id.tvResult);
+
+        navPurchases = findViewById(R.id.navPurchases);
+        navPeople = findViewById(R.id.navPeople);
+        activateTab(navPurchases, navPeople);
+
+        navPurchases.setOnClickListener(v -> activateTab(navPurchases, navPeople));
+        navPeople.setOnClickListener(v -> {
+            activateTab(navPeople, navPurchases);
+            startActivity(new Intent(this, PersonsActivity.class));
+            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
+            finish();
+        });
+    }
+
+    private void processImage(Uri uri) {
+        if (uri == null) return;
+        try {
+            InputImage image = InputImage.fromFilePath(this, uri);
+            TextRecognizer recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS);
+            recognizer.process(image)
+                    .addOnSuccessListener(result -> {
+                        parseText(result.getText());
+                        itemAdapter.notifyDataSetChanged();
+                    })
+                    .addOnFailureListener(e -> Toast.makeText(this, "OCR failed", Toast.LENGTH_SHORT).show());
+        } catch (IOException e) {
+            Toast.makeText(this, "Image error", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void parseText(String text) {
+        items.clear();
+        String[] lines = text.split("\n");
+        for (String line : lines) {
+            line = line.trim();
+            if (line.isEmpty()) continue;
+            String[] parts = line.split(" ");
+            if (parts.length < 2) continue;
+            String pricePart = parts[parts.length - 1].replace("€", "").replace(",", ".");
+            try {
+                double price = Double.parseDouble(pricePart);
+                StringBuilder nameBuilder = new StringBuilder();
+                for (int i = 0; i < parts.length - 1; i++) {
+                    if (i > 0) nameBuilder.append(' ');
+                    nameBuilder.append(parts[i]);
+                }
+                items.add(new PurchaseItem(nameBuilder.toString(), price));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+    }
+
+    private void createInvoice() {
+        if (!itemAdapter.allItemsAssigned()) {
+            Toast.makeText(this, getString(R.string.error_assign_person), Toast.LENGTH_LONG).show();
+            return;
+        }
+        Map<Long, Double> totals = itemAdapter.calculateTotals();
+        StringBuilder sb = new StringBuilder();
+        for (Person p : dbHelper.getAllPersons()) {
+            Double value = totals.get(p.getId());
+            if (value != null) {
+                sb.append(String.format(Locale.getDefault(), "%s: %.2f€\n", p.getName(), value));
+            }
+        }
+        tvResult.setText(sb.toString());
+    }
+
+    private void activateTab(TextView active, TextView inactive) {
+        active.setBackgroundColor(ContextCompat.getColor(this, R.color.tab_active));
+        inactive.setBackgroundColor(ContextCompat.getColor(this, R.color.tab_inactive));
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
@@ -1,0 +1,68 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PersonSelectAdapter extends RecyclerView.Adapter<PersonSelectAdapter.PersonSelectViewHolder> {
+
+    private final List<Person> people;
+    private final Set<Long> selectedIds = new HashSet<>();
+
+    public PersonSelectAdapter(List<Person> people) {
+        this.people = people;
+    }
+
+    public Set<Long> getSelectedIds() {
+        return new HashSet<>(selectedIds);
+    }
+
+    @NonNull
+    @Override
+    public PersonSelectViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_person_checkbox, parent, false);
+        return new PersonSelectViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PersonSelectViewHolder holder, int position) {
+        Person person = people.get(position);
+        holder.name.setText(person.getName());
+        holder.checkBox.setOnCheckedChangeListener(null);
+        holder.checkBox.setChecked(selectedIds.contains(person.getId()));
+        holder.checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (isChecked) {
+                selectedIds.add(person.getId());
+            } else {
+                selectedIds.remove(person.getId());
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return people.size();
+    }
+
+    static class PersonSelectViewHolder extends RecyclerView.ViewHolder {
+        final TextView name;
+        final CheckBox checkBox;
+
+        PersonSelectViewHolder(@NonNull View itemView) {
+            super(itemView);
+            name = itemView.findViewById(R.id.tvName);
+            checkBox = itemView.findViewById(R.id.cbPerson);
+        }
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseItem.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseItem.java
@@ -1,0 +1,19 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+public class PurchaseItem {
+    private final String name;
+    private final double price;
+
+    public PurchaseItem(String name, double price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptItemAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptItemAdapter.java
@@ -1,0 +1,158 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ReceiptItemAdapter extends RecyclerView.Adapter<ReceiptItemAdapter.ItemViewHolder> {
+
+    private final List<PurchaseItem> items;
+    private final List<Person> persons;
+    private final Map<Integer, Set<Long>> assignments = new HashMap<>();
+
+    public ReceiptItemAdapter(List<PurchaseItem> items, List<Person> persons) {
+        this.items = items;
+        this.persons = persons;
+    }
+
+    public Map<Long, Double> calculateTotals() {
+        Map<Long, Double> totals = new HashMap<>();
+        for (int i = 0; i < items.size(); i++) {
+            PurchaseItem item = items.get(i);
+            Set<Long> selected = assignments.get(i);
+            if (selected == null || selected.isEmpty()) {
+                continue;
+            }
+            double share = item.getPrice() / selected.size();
+            for (Long id : selected) {
+                double current = totals.containsKey(id) ? totals.get(id) : 0.0;
+                totals.put(id, current + share);
+            }
+        }
+        return totals;
+    }
+
+    public boolean allItemsAssigned() {
+        for (int i = 0; i < items.size(); i++) {
+            Set<Long> sel = assignments.get(i);
+            if (sel == null || sel.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public ItemViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_article, parent, false);
+        return new ItemViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ItemViewHolder holder, int position) {
+        PurchaseItem item = items.get(position);
+        holder.name.setText(item.getName());
+        holder.price.setText(String.format("%.2f€", item.getPrice()));
+        holder.container.removeAllViews();
+
+        Context ctx = holder.container.getContext();
+        CheckBox allBox = new CheckBox(ctx);
+        allBox.setText("Alle");
+        holder.container.addView(allBox);
+
+        List<CheckBox> personBoxes = new ArrayList<>();
+        for (Person p : persons) {
+            CheckBox cb = new CheckBox(ctx);
+            cb.setText(p.getName());
+            cb.setTag(p.getId());
+            holder.container.addView(cb);
+            personBoxes.add(cb);
+        }
+
+        Set<Long> selected = assignments.get(position);
+        if (selected == null) {
+            selected = new HashSet<>();
+            assignments.put(position, selected);
+        }
+
+        for (CheckBox cb : personBoxes) {
+            long id = (long) cb.getTag();
+            cb.setChecked(selected.contains(id));
+            cb.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                if (isChecked) {
+                    selected.add(id);
+                } else {
+                    selected.remove(id);
+                    allBox.setOnCheckedChangeListener(null);
+                    allBox.setChecked(false);
+                    allBox.setOnCheckedChangeListener((b, checked) -> toggleAll(checked, personBoxes, selected));
+                }
+            });
+        }
+
+        allBox.setOnCheckedChangeListener((buttonView, isChecked) -> toggleAll(isChecked, personBoxes, selected));
+    }
+
+    private void toggleAll(boolean checked, List<CheckBox> boxes, Set<Long> sel) {
+        if (checked) {
+            for (CheckBox cb : boxes) {
+                cb.setOnCheckedChangeListener(null);
+                cb.setChecked(true);
+                cb.setOnCheckedChangeListener((buttonView, isC) -> {
+                    if (isC) {
+                        sel.add((Long) cb.getTag());
+                    } else {
+                        sel.remove((Long) cb.getTag());
+                    }
+                });
+                sel.add((Long) cb.getTag());
+            }
+        } else {
+            for (CheckBox cb : boxes) {
+                cb.setOnCheckedChangeListener(null);
+                cb.setChecked(false);
+                cb.setOnCheckedChangeListener((buttonView, isC) -> {
+                    if (isC) {
+                        sel.add((Long) cb.getTag());
+                    } else {
+                        sel.remove((Long) cb.getTag());
+                    }
+                });
+            }
+            sel.clear();
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class ItemViewHolder extends RecyclerView.ViewHolder {
+        final TextView name;
+        final TextView price;
+        final LinearLayout container;
+
+        ItemViewHolder(@NonNull View itemView) {
+            super(itemView);
+            name = itemView.findViewById(R.id.tvItemName);
+            price = itemView.findViewById(R.id.tvItemPrice);
+            container = itemView.findViewById(R.id.checkboxContainer);
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".NewPurchaseActivity">
+
+    <LinearLayout
+        android:id="@+id/headerLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:background="@color/lidlBlue"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tvHeader"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/title_new_purchase"
+            android:textColor="@color/white"
+            android:textStyle="bold"
+            android:textSize="24sp" />
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerPersonsSelect"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+
+    <CheckBox
+        android:id="@+id/cbPaid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/checkbox_paid"
+        android:layout_margin="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/recyclerPersonsSelect" />
+
+    <Button
+        android:id="@+id/btnUploadReceipt"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/upload_receipt"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cbPaid" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerItems"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnUploadReceipt"
+        app:layout_constraintBottom_toTopOf="@id/btnCreateInvoice" />
+
+    <Button
+        android:id="@+id/btnCreateInvoice"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/create_invoice"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/recyclerItems" />
+
+    <TextView
+        android:id="@+id/tvResult"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:layout_margin="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnCreateInvoice"
+        app:layout_constraintBottom_toTopOf="@id/customFooter" />
+
+    <LinearLayout
+        android:id="@+id/customFooter"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/navPurchases"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Einkäufe"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:background="@color/tab_active"
+            android:clickable="true"
+            android:focusable="true" />
+
+        <TextView
+            android:id="@+id/navPeople"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Personen"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:background="@color/tab_inactive"
+            android:clickable="true"
+            android:focusable="true" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_article.xml
+++ b/app/src/main/res/layout/item_article.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardBackgroundColor="@color/lightGray">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tvItemName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvItemPrice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/checkboxContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_person_checkbox.xml
+++ b/app/src/main/res/layout/item_person_checkbox.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardBackgroundColor="@color/lightGray">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/tvName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:textSize="18sp" />
+
+        <CheckBox
+            android:id="@+id/cbPerson"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,9 @@
     <string name="action_delete">Löschen</string>
     <string name="confirm_delete_person">Möchtest du diese Person wirklich löschen?</string>
     <string name="hint_person_name">Name</string>
+    <string name="title_new_purchase">Neuer Einkauf</string>
+    <string name="upload_receipt">Upload Kassenbon</string>
+    <string name="checkbox_paid">bezahlt</string>
+    <string name="create_invoice">Rechnung erstellen</string>
+    <string name="error_assign_person">Bitte weise allen Artikeln mindestens eine Person zu.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add new screen `NewPurchaseActivity` with OCR-based receipt parsing
- create adapters for person selection and receipt items
- provide layouts for new screen and list items
- extend strings and manifest
- add ML Kit dependency

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c330fd93c8328a4c5f734f7b290c3