### PR TITLE
Add selection dialog for participants

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
@@ -4,13 +4,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,6 +20,13 @@ public class PersonSelectAdapter extends RecyclerView.Adapter<PersonSelectAdapte
 
     public PersonSelectAdapter(List<Person> people) {
         this.people = people;
+    }
+
+    public void updateData(List<Person> newPeople) {
+        people.clear();
+        people.addAll(newPeople);
+        selectedIds.clear();
+        notifyDataSetChanged();
     }
 
     public Set<Long> getSelectedIds() {

--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -29,14 +29,24 @@
             android:textSize="24sp" />
     </LinearLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerPersonsSelect"
-        android:layout_width="0dp"
+    <Button
+        android:id="@+id/btnAddPersonSelect"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/add_person"
         android:layout_marginTop="16dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerPersonsSelect"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnAddPersonSelect" />
 
     <CheckBox
         android:id="@+id/cbPaid"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="checkbox_paid">bezahlt</string>
     <string name="create_invoice">Rechnung erstellen</string>
     <string name="error_assign_person">Bitte weise allen Artikeln mindestens eine Person zu.</string>
+    <string name="dialog_select_persons_title">Personen auswählen</string>
 </resources>


### PR DESCRIPTION
## Summary
- start new purchases with no persons
- add button to choose persons for a purchase via dialog
- update lists and totals based on selected persons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c3ec7f1d48328b27d7b57db552007