### PR TITLE
Fix article display and parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -108,6 +108,11 @@ public class NewPurchaseActivity extends AppCompatActivity {
 
         items.clear();
         items.addAll(data.getItems());
+        if (items.isEmpty()) {
+            itemRecycler.setVisibility(View.GONE);
+        } else {
+            itemRecycler.setVisibility(View.VISIBLE);
+        }
 
         StringBuilder sb = new StringBuilder();
         if (data.getDateTime() != null) {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -22,9 +22,9 @@ public class ReceiptParser {
      * </pre>
      */
     private static final Pattern ITEM_PATTERN =
-            Pattern.compile("^(.+?)\\s+(-?[0-9]+,[0-9]{2})(?:\\s*(?:€|EUR))?\\s*[A-Z]?$");
+            Pattern.compile("^(.+?)\\s+(\\d+[.,]?\\d*)\\s*(?:€|EUR)?\\s*[A-Z]?$");
     private static final Pattern TOTAL_PATTERN =
-            Pattern.compile("(?i)zu\\s+zahlen.*?(-?[0-9]+,[0-9]{2})");
+            Pattern.compile("(?i)zu\\s+zahlen.*?(\\d+[.,]?\\d*)");
     private static final Pattern DATE_TIME_PATTERN =
             Pattern.compile("(\\d{2}\\.\\d{2}\\.\\d{4})\\s+(\\d{2}:\\d{2})");
     private static final Pattern CITY_PATTERN =


### PR DESCRIPTION
## Summary
- parse items with a more tolerant regex so prices like `1,99` or `1.99` work
- hide article list when no items were detected and show it otherwise

## Testing
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d42a7f54483289e8f6d44733b69d2