### PR TITLE
Improve receipt OCR item filtering

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -22,7 +22,11 @@ public class ReceiptParser {
      * </pre>
      */
     private static final Pattern ITEM_PATTERN =
-            Pattern.compile("^(.+?)\\s+(\\d+[.,]?\\d*)\\s*(?:€|EUR)?\\s*[A-Z]?$");
+            Pattern.compile("^(.+?)\\s+(\\d+[.,]\\d{2})\\s*(?:€|EUR)?\\s*[A-Z]?$");
+
+    /** Pattern for lines that should be ignored when parsing items */
+    private static final Pattern IGNORE_PATTERN =
+            Pattern.compile("(?i)(stra\\u00dfe|signaturzähler|ta-?nr)");
     private static final Pattern TOTAL_PATTERN =
             Pattern.compile("(?i)zu\\s+zahlen.*?(\\d+[.,]?\\d*)");
     private static final Pattern DATE_TIME_PATTERN =
@@ -41,6 +45,7 @@ public class ReceiptParser {
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i].trim();
             if (line.isEmpty()) continue;
+            if (IGNORE_PATTERN.matcher(line).find()) continue;
 
             if (total == 0.0) {
                 Matcher totalMatcher = TOTAL_PATTERN.matcher(line);


### PR DESCRIPTION
## Summary
- filter out address, TA number and signature lines during OCR parsing
- require decimal prices when recognizing items

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d45bc67248328a5dfdaadfffa8f1a