### PR TITLE
Implement simple receipt parser method

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Artikel.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Artikel.java
@@ -1,0 +1,16 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+public class Artikel {
+    public String name;
+    public double preis;
+
+    public Artikel(String name, double preis) {
+        this.name = name;
+        this.preis = preis;
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + preis + " €";
+    }
+}

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
@@ -1,0 +1,31 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SimpleReceiptParserTest {
+    @Test
+    public void parseBonExtractsData() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Cherrystrauchtomaten 1,79 A\n" +
+                "Preisvorteil -0,20\n" +
+                "Laugenbrezel 10er 1,99 A\n" +
+                "Gesamt: 19,86 \u20ac\n" +
+                "18.06.2025";
+
+        List<Artikel> items = ReceiptParser.parseBon(text);
+
+        assertEquals("Allersberger Straße 130, 90461 Nürnberg", ReceiptParser.adresse);
+        assertEquals("18.06.2025", ReceiptParser.datum);
+        assertEquals(19.86, ReceiptParser.gesamtpreis, 0.001);
+        assertEquals(2, items.size());
+        assertEquals("Cherrystrauchtomaten", items.get(0).name);
+        assertEquals(1.59, items.get(0).preis, 0.001);
+        assertEquals("Laugenbrezel 10er", items.get(1).name);
+        assertEquals(1.99, items.get(1).preis, 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple `Artikel` data class
- extend `ReceiptParser` with static fields and new `parseBon` method
- add tests covering `parseBon`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d73077be08328970aebea45bad464