### PR TITLE
Add logging for OCR and receipt parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -7,6 +7,7 @@ import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.view.View;
+import android.util.Log;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -103,6 +104,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
     }
 
     private void parseText(String text) {
+        Log.d("OCR", "Erkannter Bon-Text:\n" + text);
         ReceiptParser parser = new ReceiptParser();
         ReceiptData data = parser.parse(text);
 

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import android.util.Log;
 
 public class ReceiptParser {
 
@@ -140,6 +141,7 @@ public class ReceiptParser {
 
         for (int i = 2; i < lines.length; i++) {
             String line = lines[i].trim();
+            Log.d("ReceiptParser", "Zeile: '" + line + "'");
             if (line.isEmpty()) {
                 continue;
             }
@@ -156,6 +158,7 @@ public class ReceiptParser {
                     artikelListe.remove(artikelListe.size() - 1);
                     lastArtikel = null;
                 }
+                Log.d("ReceiptParser", "→ Preisvorteil erkannt: " + advMatcher.group(1));
                 continue;
             }
 
@@ -165,18 +168,21 @@ public class ReceiptParser {
                 double preis = parseDouble(itemMatcher.group(2));
                 lastArtikel = new Artikel(name, preis);
                 artikelListe.add(lastArtikel);
+                Log.d("ReceiptParser", "→ Artikel erkannt: " + itemMatcher.group(1) + " / " + itemMatcher.group(2));
                 continue;
             }
 
             Matcher totalMatcher = totalPattern.matcher(line);
             if (totalMatcher.find()) {
                 gesamtpreis = parseDouble(totalMatcher.group(2));
+                Log.d("ReceiptParser", "→ Gesamtpreis erkannt: " + totalMatcher.group(2));
                 continue;
             }
 
             Matcher dateMatcher = datePattern.matcher(line);
             if (dateMatcher.find()) {
                 datum = dateMatcher.group(1);
+                Log.d("ReceiptParser", "→ Datum erkannt: " + dateMatcher.group());
             }
         }
 


### PR DESCRIPTION
## Summary
- log recognized OCR text in `NewPurchaseActivity`
- log each parsed line and matches in `ReceiptParser`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d760dee8483288e0fb4243d62c2e3