### PR TITLE
Add summary logs after receipt parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -108,6 +108,23 @@ public class ReceiptParser {
             }
         }
 
+        for (PurchaseItem item : items) {
+            Log.d("ReceiptParser", "Artikel: " + item.getName() + " / " + item.getPrice());
+        }
+        if (street != null || city != null) {
+            StringBuilder addr = new StringBuilder();
+            if (street != null) addr.append(street);
+            if (city != null) {
+                if (addr.length() > 0) addr.append(", ");
+                addr.append(city);
+            }
+            Log.d("ReceiptParser", "Adresse: " + addr.toString());
+        }
+        if (dateTime != null) {
+            Log.d("ReceiptParser", "Datum: " + dateTime.toString());
+        }
+        Log.d("ReceiptParser", "Gesamtpreis: " + total);
+
         return new ReceiptData(items, total, street, city, dateTime);
     }
 
@@ -185,6 +202,13 @@ public class ReceiptParser {
                 Log.d("ReceiptParser", "→ Datum erkannt: " + dateMatcher.group());
             }
         }
+
+        for (Artikel a : artikelListe) {
+            Log.d("ReceiptParser", "Artikel: " + a.name + " / " + a.preis);
+        }
+        Log.d("ReceiptParser", "Adresse: " + adresse);
+        Log.d("ReceiptParser", "Datum: " + datum);
+        Log.d("ReceiptParser", "Gesamtpreis: " + gesamtpreis);
 
         return artikelListe;
     }


### PR DESCRIPTION
## Summary
- add debug output at end of `parse()`
- print parsed articles, address, date and total in `parseBon()`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d779e27d08328a42e805006f14b90