### PR TITLE
Implement parseReceipt helper

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ParsedReceipt.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ParsedReceipt.java
@@ -1,0 +1,33 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import java.util.List;
+
+public class ParsedReceipt {
+    private final List<Artikel> items;
+    private final String date;
+    private final double total;
+    private final String address;
+
+    public ParsedReceipt(List<Artikel> items, String date, double total, String address) {
+        this.items = items;
+        this.date = date;
+        this.total = total;
+        this.address = address;
+    }
+
+    public List<Artikel> getItems() {
+        return items;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -159,6 +159,44 @@ public class ReceiptParser {
     }
 
     /**
+     * Convenience method returning a {@link ParsedReceipt} object for the given
+     * raw receipt text. It internally delegates to {@link #parse(String)} and
+     * converts the {@link PurchaseItem}s into the simpler {@link Artikel}
+     * representation used by some parts of the application.
+     */
+    public static ParsedReceipt parseReceipt(String text) {
+        ReceiptParser parser = new ReceiptParser();
+        ReceiptData data = parser.parse(text);
+
+        // convert items
+        List<Artikel> artikelListe = new ArrayList<>();
+        for (PurchaseItem pi : data.getItems()) {
+            artikelListe.add(new Artikel(pi.getName(), pi.getPrice()));
+        }
+
+        // format date if available
+        String datumStr = null;
+        if (data.getDateTime() != null) {
+            DateTimeFormatter df = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+            datumStr = data.getDateTime().toLocalDate().format(df);
+        }
+
+        // build address string
+        String adresseStr = null;
+        if (data.getStreet() != null || data.getCity() != null) {
+            StringBuilder sb = new StringBuilder();
+            if (data.getStreet() != null) sb.append(data.getStreet());
+            if (data.getCity() != null) {
+                if (sb.length() > 0) sb.append(", ");
+                sb.append(data.getCity());
+            }
+            adresseStr = sb.toString();
+        }
+
+        return new ParsedReceipt(artikelListe, datumStr, data.getTotal(), adresseStr);
+    }
+
+    /**
      * Parses a receipt into a simple list of {@link Artikel} objects and
      * populates the static fields {@link #adresse}, {@link #datum} and
      * {@link #gesamtpreis}. This method is intentionally simple and primarily

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ParseReceiptMethodTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ParseReceiptMethodTest.java
@@ -1,0 +1,35 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ParseReceiptMethodTest {
+    @Test
+    public void parseReceiptExtractsData() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Cherrystrauchtomaten\n" +
+                "1,79 A\n" +
+                "Preisvorteil -0,20\n" +
+                "Laugenbrezel 10er\n" +
+                "1,99\n" +
+                "Gesamtsumme 19,86\n" +
+                "18.06.2025";
+
+        ParsedReceipt result = ReceiptParser.parseReceipt(text);
+
+        assertEquals("Allersberger Straße 130, 90461 Nürnberg", result.getAddress());
+        assertEquals("18.06.2025", result.getDate());
+        assertEquals(19.86, result.getTotal(), 0.001);
+
+        List<Artikel> items = result.getItems();
+        assertEquals(2, items.size());
+        assertEquals("Cherrystrauchtomaten", items.get(0).name);
+        assertEquals(1.59, items.get(0).preis, 0.001);
+        assertEquals("Laugenbrezel 10er", items.get(1).name);
+        assertEquals(1.99, items.get(1).preis, 0.001);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ParsedReceipt` data class
- implement `parseReceipt` convenience method in `ReceiptParser`
- test extraction via new method

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d7b511e3083289db936d77e0776b8