### PR TITLE
Refactor receipt parser and introduce Article model

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Article.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Article.java
@@ -1,0 +1,23 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+public class Article {
+    private String name;
+    private double price;
+
+    public Article(String name, double price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ParsedReceipt.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ParsedReceipt.java
@@ -3,19 +3,19 @@ package de.th.nuernberg.bme.lidlsplit;
 import java.util.List;
 
 public class ParsedReceipt {
-    private final List<Artikel> items;
+    private final List<Article> items;
     private final String date;
     private final double total;
     private final String address;
 
-    public ParsedReceipt(List<Artikel> items, String date, double total, String address) {
+    public ParsedReceipt(List<Article> items, String date, double total, String address) {
         this.items = items;
         this.date = date;
         this.total = total;
         this.address = address;
     }
 
-    public List<Artikel> getItems() {
+    public List<Article> getItems() {
         return items;
     }
 

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ParseReceiptMethodTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ParseReceiptMethodTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import de.th.nuernberg.bme.lidlsplit.Article;
+
 import static org.junit.Assert.*;
 
 public class ParseReceiptMethodTest {
@@ -25,11 +27,11 @@ public class ParseReceiptMethodTest {
         assertEquals("18.06.2025", result.getDate());
         assertEquals(19.86, result.getTotal(), 0.001);
 
-        List<Artikel> items = result.getItems();
+        List<Article> items = result.getItems();
         assertEquals(2, items.size());
-        assertEquals("Cherrystrauchtomaten", items.get(0).name);
-        assertEquals(1.59, items.get(0).preis, 0.001);
-        assertEquals("Laugenbrezel 10er", items.get(1).name);
-        assertEquals(1.99, items.get(1).preis, 0.001);
+        assertEquals("Cherrystrauchtomaten", items.get(0).getName());
+        assertEquals(1.59, items.get(0).getPrice(), 0.001);
+        assertEquals("Laugenbrezel 10er", items.get(1).getName());
+        assertEquals(1.99, items.get(1).getPrice(), 0.001);
     }
 }


### PR DESCRIPTION
## Summary
- add new `Article` data class
- adjust `ParsedReceipt` to use `Article`
- rewrite `ReceiptParser.parseReceipt` to better handle multi-line items, discounts and totals
- add `parseGermanPrice` helper
- update unit test for new data model

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d7e2634488328bd96957b489f8722