### PR TITLE
Add detailed logging for receipt parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -105,8 +105,10 @@ public class NewPurchaseActivity extends AppCompatActivity {
 
     private void parseText(String text) {
         Log.d("OCR", "Erkannter Bon-Text:\n" + text);
+        Log.d("OCR", "Starte Parsing des OCR-Textes…");
         ReceiptParser parser = new ReceiptParser();
         ReceiptData data = parser.parse(text);
+        Log.d("OCR", "Parsing abgeschlossen, Artikelanzahl: " + data.getItems().size());
 
         items.clear();
         items.addAll(data.getItems());


### PR DESCRIPTION
## Summary
- add debug logs during receipt parsing to trace OCR results, detected data and items
- log start and end of OCR parsing in `NewPurchaseActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d80e322f88328bc0277232ac55a73