### PR TITLE
Display parsed items in new purchase screen

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -44,6 +44,9 @@ public class NewPurchaseActivity extends AppCompatActivity {
     private TextView navPeople;
     private TextView tvResult;
     private TextView tvPaidLabel;
+    private TextView tvAddress;
+    private TextView tvDate;
+    private TextView tvTotal;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -73,6 +76,9 @@ public class NewPurchaseActivity extends AppCompatActivity {
 
         tvResult = findViewById(R.id.tvResult);
         tvPaidLabel = findViewById(R.id.tvPaidLabel);
+        tvAddress = findViewById(R.id.tvAddress);
+        tvDate = findViewById(R.id.tvDate);
+        tvTotal = findViewById(R.id.tvTotal);
 
         navPurchases = findViewById(R.id.navPurchases);
         navPeople = findViewById(R.id.navPeople);
@@ -118,21 +124,30 @@ public class NewPurchaseActivity extends AppCompatActivity {
             itemRecycler.setVisibility(View.VISIBLE);
         }
 
-        StringBuilder sb = new StringBuilder();
+        tvResult.setText("");
+
         if (data.getDateTime() != null) {
             DateTimeFormatter df = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
-            sb.append(df.format(data.getDateTime())).append("\n");
+            tvDate.setText(df.format(data.getDateTime()));
+        } else {
+            tvDate.setText("");
         }
+
+        StringBuilder addr = new StringBuilder();
         if (data.getStreet() != null) {
-            sb.append(data.getStreet()).append("\n");
+            addr.append(data.getStreet());
         }
         if (data.getCity() != null) {
-            sb.append(data.getCity()).append("\n");
+            if (addr.length() > 0) addr.append("\n");
+            addr.append(data.getCity());
         }
+        tvAddress.setText(addr.toString());
+
         if (data.getTotal() != 0.0) {
-            sb.append(String.format(Locale.getDefault(), "Gesamt: %.2f€", data.getTotal()));
+            tvTotal.setText(getString(R.string.total_label, data.getTotal()));
+        } else {
+            tvTotal.setText("");
         }
-        tvResult.setText(sb.toString());
     }
 
     private void createInvoice() {

--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -29,7 +29,7 @@
             android:textSize="24sp" />
     </LinearLayout>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/scrollContent"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -95,13 +95,6 @@
                 android:layout_marginTop="8dp"
                 android:layout_gravity="center_horizontal" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerItems"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:nestedScrollingEnabled="false" />
-
             <Button
                 android:id="@+id/btnCreateInvoice"
                 android:layout_width="wrap_content"
@@ -113,6 +106,40 @@
                 android:layout_gravity="center_horizontal" />
 
             <TextView
+                android:id="@+id/tvAddress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/black" />
+
+            <TextView
+                android:id="@+id/tvDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/black" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerItems"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:layout_marginTop="8dp"
+                android:nestedScrollingEnabled="false" />
+
+            <TextView
+                android:id="@+id/tvTotal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/black" />
+
+            <TextView
                 android:id="@+id/tvResult"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -120,7 +147,7 @@
                 android:layout_margin="8dp" />
 
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
     <LinearLayout
         android:id="@+id/customFooter"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="create_invoice">Rechnung erstellen</string>
     <string name="error_assign_person">Bitte weise allen Artikeln mindestens eine Person zu.</string>
     <string name="dialog_select_persons_title">Personen auswählen</string>
+    <string name="total_label">Gesamt: %1$.2f€</string>
 </resources>


### PR DESCRIPTION
## Summary
- show parsed receipt details in `NewPurchaseActivity`
- move list below `Rechnung erstellen` button and give it a fixed height
- use individual fields for receipt address, date and total

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d82dd19a48328b56ba9b9a6e41703