### PR TITLE
Improve ReceiptParser reliability

### DIFF
--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
@@ -33,4 +33,29 @@ public class ReceiptParserTest {
         assertEquals(19.86, data.getTotal(), 0.001);
         assertEquals(LocalDateTime.of(2025, 6, 18, 0, 0), data.getDateTime());
     }
+
+    @Test
+    public void ignoresJunkLines() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Cherrystrauchtomaten\n" +
+                "1,79\n" +
+                "Preisvorteil -0,20\n" +
+                "Laugenbrezel 10er\n" +
+                "1,99\n" +
+                "MWST 7%\n" +
+                "Karte Visa\n" +
+                "zu zahlen 19,86\n" +
+                "18.06.2025";
+
+        ReceiptParser parser = new ReceiptParser();
+        ReceiptData data = parser.parse(text);
+
+        assertEquals(2, data.getItems().size());
+        assertEquals("Cherrystrauchtomaten", data.getItems().get(0).getName());
+        assertEquals(1.59, data.getItems().get(0).getPrice(), 0.001);
+        assertEquals("Laugenbrezel 10er", data.getItems().get(1).getName());
+        assertEquals(1.99, data.getItems().get(1).getPrice(), 0.001);
+        assertEquals(19.86, data.getTotal(), 0.001);
+    }
 }


### PR DESCRIPTION
## Summary
- refine regex for item lines to allow digits but require letters
- expand ignore list to skip more non-article lines
- parse total before ignoring junk lines
- avoid treating lines without letters as article names
- test that junk lines like `MWST` and `Karte` are ignored

## Testing
- `gradle test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b22434c8328979e4bac12a96676