### PR TITLE
Improve total detection

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -48,7 +48,7 @@ public class ReceiptParser {
             "^([A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß0-9\\s\\-.]*?)\\s+(\\d+[.,]\\d{2})\\s*(?:€|EUR|A)?$",
             Pattern.CASE_INSENSITIVE);
     private static final Pattern TOTAL_PATTERN =
-            Pattern.compile("(?i)(?:gesamtsumme|summe|gesamt|zu\\s+zahlen).*?(\\d+[.,]?\\d*)");
+            Pattern.compile("(?i)(?:gesamtsumme|summe|gesamt|zu\\s+zahlen|betrag).*?(\\d+[.,]?\\d*)");
     private static final Pattern DATE_PATTERN =
             Pattern.compile("(\\d{2}\\.\\d{2}\\.(?:\\d{2}|\\d{4}))(?:\\s+(\\d{2}:\\d{2}))?");
     private static final Pattern ISO_DATE_PATTERN =
@@ -65,7 +65,7 @@ public class ReceiptParser {
     // names. This helps to avoid false positives such as "MWST" or "Karte" when
     // the OCR output is noisy.
     private static final Pattern IGNORE_LINE_PATTERN = Pattern.compile(
-            "(?i)(TA-?Nr|TSE|Bonkopie|Seriennummer|Transaktionsnummer|UST-ID|Kartennr|Seriennr|Signatur|Beleg|Kontaktlos|Karte|MWST|^EUR$|www\\.lidl\\.de)");
+            "(?i)(TA-?Nr|TSE|Bonkopie|Seriennummer|Transaktionsnummer|UST-ID|Kartennr|Seriennr|Signatur|Beleg|Kontaktlos|Karte|MWST|Betrag|^EUR$|www\\.lidl\\.de)");
 
     public ReceiptData parse(String text) {
         Log.d("ReceiptParser", "OCR-Rohtext:\n" + text);

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
@@ -58,4 +58,19 @@ public class ReceiptParserTest {
         assertEquals(1.99, data.getItems().get(1).getPrice(), 0.001);
         assertEquals(19.86, data.getTotal(), 0.001);
     }
+
+    @Test
+    public void parseTotalWithBetrag() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Betrag 19,86\n" +
+                "18.06.2025";
+
+        ReceiptParser parser = new ReceiptParser();
+        ReceiptData data = parser.parse(text);
+
+        assertEquals(19.86, data.getTotal(), 0.001);
+        assertEquals("Allersberger Straße 130", data.getStreet());
+        assertEquals("90461 Nürnberg", data.getCity());
+    }
 }


### PR DESCRIPTION
## Summary
- handle receipts that show "Betrag" as the total line
- skip lines containing "Betrag" when detecting article names
- test for parsing totals using "Betrag"

## Testing
- `./gradlew test` *(fails: unable to access Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d936745648328b71a0af6c4adc5e1