### PR TITLE
Handle 'Zu zahlen' total

### DIFF
--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/ReceiptParserTest.java
@@ -73,4 +73,24 @@ public class ReceiptParserTest {
         assertEquals("Allersberger Straße 130", data.getStreet());
         assertEquals("90461 Nürnberg", data.getCity());
     }
+
+    @Test
+    public void stopsParsingAfterZuZahlen() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Cherrystrauchtomaten\n" +
+                "1,79\n" +
+                "Laugenbrezel 10er\n" +
+                "1,99\n" +
+                "Zu zahlen 19,86\n" +
+                "Pfand 0,25\n" +
+                "18.06.2025";
+
+        ReceiptParser parser = new ReceiptParser();
+        ReceiptData data = parser.parse(text);
+
+        assertEquals(2, data.getItems().size());
+        assertEquals(19.86, data.getTotal(), 0.001);
+        assertEquals(LocalDateTime.of(2025, 6, 18, 0, 0), data.getDateTime());
+    }
 }

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
@@ -56,4 +56,25 @@ public class SimpleReceiptParserTest {
         assertEquals("Laugenbrezel 10er", items.get(1).name);
         assertEquals(1.99, items.get(1).preis, 0.001);
     }
+
+    @Test
+    public void parseBonStopsAfterZuZahlen() {
+        String text = "Allersberger Straße 130\n" +
+                "90461 Nürnberg\n" +
+                "Cherrystrauchtomaten\n" +
+                "1,79\n" +
+                "Laugenbrezel 10er\n" +
+                "1,99\n" +
+                "Zu zahlen 19,86\n" +
+                "Pfand\n" +
+                "0,25\n" +
+                "18.06.2025";
+
+        List<Artikel> items = ReceiptParser.parseBon(text);
+
+        assertEquals(2, items.size());
+        assertEquals(19.86, ReceiptParser.gesamtpreis, 0.001);
+        assertEquals("Cherrystrauchtomaten", items.get(0).name);
+        assertEquals("Laugenbrezel 10er", items.get(1).name);
+    }
 }


### PR DESCRIPTION
## Summary
- stop parsing articles in `parse` when encountering the line `Zu zahlen` and use its price as the total
- stop parsing articles in `parseBon` once `Zu zahlen` appears
- add unit tests covering the new behaviour

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d992ca1d48328ba8d6a3555a19beb