### PR TITLE
Handle receipt end at 'Zu zahlen'

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -478,23 +478,14 @@ public class ReceiptParser {
                 break;
             }
 
-            if (lower.contains("summe")) {
-                Matcher pm = priceOnly.matcher(line);
-                if (pm.find()) {
-                    gesamtpreis = parseDouble(pm.group());
-                } else if (i + 1 < lines.length) {
-                    String next = lines[i + 1].trim();
-                    pm = priceOnly.matcher(next);
-                    if (pm.matches()) {
-                        gesamtpreis = parseDouble(pm.group());
-                        i++;
-                    }
-                }
+            // Zeilen wie "Summe" oder "Gesamter Preisvorteil" ignorieren
+            if (lower.contains("summe") || (lower.contains("preisvorteil") && lower.contains("gesamt"))) {
+                lastName = null;
                 continue;
             }
 
             // Preisvorteil verarbeiten
-            if (lower.contains("preisvorteil") && !artikelListe.isEmpty()) {
+            if (lower.contains("preisvorteil") && !lower.contains("gesamt") && !artikelListe.isEmpty()) {
                 Matcher pm = priceOnly.matcher(line);
                 if (pm.find()) {
                     double diff = parseDouble(pm.group());

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
@@ -11,13 +11,13 @@ public class SimpleReceiptParserTest {
     public void parseBonExtractsData() {
         String text = "Allersberger Straße 130\n" +
                 "90461 Nürnberg\n" +
+                "18.06.2025\n" +
                 "Cherrystrauchtomaten\n" +
                 "1,79 A\n" +
                 "Preisvorteil -0,20\n" +
                 "Laugenbrezel 10er\n" +
                 "1,99 A\n" +
-                "Gesamt: 19,86 \u20ac\n" +
-                "18.06.2025";
+                "Zu zahlen 19,86";
 
         List<Artikel> items = ReceiptParser.parseBon(text);
 


### PR DESCRIPTION
## Summary
- stop collecting articles when reaching the *Zu zahlen* line
- ignore summary lines like `Summe` or `Gesamter Preisvorteil`
- update unit tests for new receipt structure

## Testing
- `./gradlew test` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685d9f3ce8e48328939a8d09ec90605b