### PR TITLE
Fix Preisvorteil handling in simple parser

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -496,9 +496,20 @@ public class ReceiptParser {
 
             // Preisvorteil (nicht gesamt) verrechnen und Zeile ignorieren
             if (lower.contains("preisvorteil")) {
+                double diff = Double.NaN;
                 Matcher advMatcher = ADVANTAGE_PATTERN.matcher(line);
-                if (advMatcher.find() && !artikelListe.isEmpty()) {
-                    double diff = parseDouble(advMatcher.group(1));
+                if (advMatcher.find()) {
+                    diff = parseDouble(advMatcher.group(1));
+                } else if (i + 1 < lines.length) {
+                    String next = lines[i + 1].trim();
+                    Matcher pm = priceOnly.matcher(next);
+                    if (pm.matches()) {
+                        diff = parseDouble(pm.group(1));
+                        i++; // consume the price line
+                    }
+                }
+
+                if (!Double.isNaN(diff) && !artikelListe.isEmpty()) {
                     Artikel last = artikelListe.get(artikelListe.size() - 1);
                     double newPrice = last.preis + diff;
                     if (newPrice < 0) {

--- a/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
+++ b/app/src/test/java/de/th/nuernberg/bme/lidlsplit/SimpleReceiptParserTest.java
@@ -77,4 +77,19 @@ public class SimpleReceiptParserTest {
         assertEquals("Cherrystrauchtomaten", items.get(0).name);
         assertEquals("Laugenbrezel 10er", items.get(1).name);
     }
+
+    @Test
+    public void parseBonHandlesMultilinePreisvorteil() {
+        String text = "Brot\n" +
+                "1,99\n" +
+                "PREISVORTEIL\n" +
+                "-0,20\n" +
+                "Zu zahlen 1,79";
+
+        List<Artikel> items = ReceiptParser.parseBon(text);
+
+        assertEquals(1, items.size());
+        assertEquals("Brot", items.get(0).name);
+        assertEquals(1.79, items.get(0).preis, 0.001);
+    }
 }


### PR DESCRIPTION
## Summary
- improve `parseBon` so that multi-line `Preisvorteil` entries adjust the previous item's price
- add regression test covering multi-line/uppercase `Preisvorteil`

## Testing
- `gradle test --no-daemon` *(fails: Plugin not found due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_685daa8dc7608328a3687179d889f0c4