### PR TITLE
Fix OCR advantage detection

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -376,7 +376,7 @@ public class ReceiptParser {
             }
 
             Matcher advMatcher = ADVANTAGE_PATTERN.matcher(rowText);
-            if (advMatcher.matches() && lastItem != null) {
+            if (advMatcher.find() && lastItem != null) {
                 double diff = parseGermanPrice(advMatcher.group(1));
                 lastItem = new PurchaseItem(lastItem.getName(), lastItem.getPrice() + diff);
                 items.set(items.size() - 1, lastItem);


### PR DESCRIPTION
## Summary
- detect price advantage lines using `Matcher.find()` in `parseOcr`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_685dacdee5448328bde630db67ad78c5