### PR TITLE
Fix duplicate variable name in parseOcr

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -428,9 +428,9 @@ public class ReceiptParser {
                 double diff = Double.NaN;
 
                 // Versuche Preisvorteil in derselben Zeile
-                Matcher advMatcher = ADVANTAGE_PATTERN.matcher(rowText);
-                if (advMatcher.find()) {
-                    diff = parseGermanPrice(advMatcher.group(1));
+                Matcher matcherAdv = ADVANTAGE_PATTERN.matcher(rowText);
+                if (matcherAdv.find()) {
+                    diff = parseGermanPrice(matcherAdv.group(1));
                 } else {
                     // Alternativ: nächster Row-Preis
                     int nextIndex = rows.indexOf(row) + 1;


### PR DESCRIPTION
## Summary
- resolve duplicate `advMatcher` variable declarations inside `parseOcr`

## Testing
- `./gradlew test --console=plain` *(fails: Unable to download Gradle wrapper due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_685db4fc3e108328987a40cb9c8a9f16