### PR TITLE
Fix price advantage handling in OCR parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -447,13 +447,16 @@ public class ReceiptParser {
                 }
 
                 if (!Double.isNaN(diff)) {
+                    // diff ist bereits negativ, direkt verwenden
                     double newPrice = lastItem.getPrice() + diff;
                     if (newPrice < 0) {
                         items.remove(items.size() - 1);
+                        Log.d("ReceiptParser", "Artikel entfernt wegen negativem Preis: " + lastItem.getName());
                         lastItem = null;
                     } else {
                         lastItem = new PurchaseItem(lastItem.getName(), newPrice);
                         items.set(items.size() - 1, lastItem);
+                        Log.d("ReceiptParser", "Preisvorteil angewendet: " + diff + " → Neuer Preis: " + newPrice);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- update price advantage handling to log removal or application

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685db6d0b89883289186ae315292b84d