### PR TITLE
Remove outdated price advantage handling

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -157,16 +157,6 @@ public class ReceiptParser {
             }
 
             if (!afterTotalLine) {
-            Matcher advMatcher = ADVANTAGE_PATTERN.matcher(line);
-            if (advMatcher.find() && lastItem != null) {
-                double adv = parseDouble(advMatcher.group(1));
-                String oldName = lastItem.getName();
-                double newPrice = lastItem.getPrice() + adv;
-                lastItem = new PurchaseItem(oldName, newPrice);
-                items.set(items.size() - 1, lastItem);
-                Log.d("ReceiptParser", "Preisvorteil erkannt: " + lastItem.getName() + " + " + adv);
-                continue;
-            }
 
             if (line.toLowerCase().contains("preisvorteil")) {
                 double diff = Double.NaN;


### PR DESCRIPTION
## Summary
- delete obsolete advantage-matcher block in `ReceiptParser`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685db7fc4c5483289902dba5d325e394