### PR TITLE
Apply automatic negative price discount logic

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -408,8 +408,17 @@ public class ReceiptParser {
             Matcher discMatcher = DISCOUNT_PATTERN.matcher(rowText);
             if (discMatcher.matches() && lastItem != null) {
                 double diff = parseGermanPrice(discMatcher.group());
-                lastItem = new PurchaseItem(lastItem.getName(), lastItem.getPrice() + diff);
-                items.set(items.size() - 1, lastItem);
+                double newPrice = lastItem.getPrice() + diff;
+
+                if (newPrice < 0) {
+                    items.remove(items.size() - 1);
+                    Log.d("ReceiptParser", "Artikel entfernt wegen negativem Gesamtpreis nach Preisvorteil: " + lastItem.getName());
+                    lastItem = null;
+                } else {
+                    lastItem = new PurchaseItem(lastItem.getName(), newPrice);
+                    items.set(items.size() - 1, lastItem);
+                    Log.d("ReceiptParser", "Negativer Preis erkannt als Preisvorteil: " + diff + " → Neuer Preis: " + newPrice);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- modify negative price handling in `ReceiptParser.parseOcr`
- remove items whose total becomes negative after discount and log the action

## Testing
- `./gradlew test` *(fails: HTTP 403 when downloading Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685db9b31dfc8328a0cc9138630b09ec