### PR TITLE
Handle discounts that might nullify item price

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -193,11 +193,19 @@ public class ReceiptParser {
             Matcher discMatcher = DISCOUNT_PATTERN.matcher(line);
             if (discMatcher.matches() && lastItem != null) {
                 double disc = parseDouble(discMatcher.group());
-                String oldName = lastItem.getName();
+
                 double newPrice = lastItem.getPrice() + disc;
-                lastItem = new PurchaseItem(oldName, newPrice);
-                items.set(items.size() - 1, lastItem);
-                Log.d("ReceiptParser", "Rabatt erkannt: " + disc + " f\u00fcr " + oldName + "; Neuer Preis: " + newPrice);
+                if (newPrice < 0) {
+                    Log.d("ReceiptParser", "Artikel entfernt wegen negativem Gesamtpreis nach Rabatt: " + lastItem.getName());
+                    items.remove(items.size() - 1);
+                    lastItem = null;
+                } else {
+                    lastItem = new PurchaseItem(lastItem.getName(), newPrice);
+                    items.set(items.size() - 1, lastItem);
+                    Log.d("ReceiptParser", "Rabatt erkannt (ohne expliziten Hinweis): " + disc + " → Neuer Preis: " + newPrice);
+                }
+
+                pendingName = null;
                 continue;
             }
             


### PR DESCRIPTION
## Summary
- improve discount handling in `ReceiptParser.parse`
- prevent negative item prices by removing item if discount exceeds price

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685dbad269c083289a8b4e0b9d9c9076