### PR TITLE
Update ReceiptParser to skip forbidden article names

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -77,7 +77,27 @@ public class ReceiptParser {
             "gesamter preisvorteil",
             "a 7 %",
             "b 19%",
-            "summe"
+            "summe",
+            "netto",
+            "vu-nummer",
+            "ox4mf",
+            "brutto",
+            "kostenlose servicenummer",
+            "details zur filiale",
+            "serial",
+            "kartennr",
+            "betrag",
+            "t-id",
+            "ust-id",
+            "transaktionsnummer",
+            "emv-daten",
+            "kontaktlos",
+            "signaturzähler",
+            "autor",
+            "www.lidl.de",
+            "allersberger",
+            "prüfwert",
+            "online"
     );
 
     // Additional keywords that indicate a line is not an article even if a
@@ -179,6 +199,11 @@ public class ReceiptParser {
             if (IGNORE_LINE_PATTERN.matcher(line).find()) {
                 // Known keywords that are not part of the article list
                 continue;
+            }
+
+            if (isForbiddenArticleName(line)) {
+                pendingName = null;
+                continue; // Zeile überspringen
             }
 
             if (!afterTotalLine) {


### PR DESCRIPTION
## Summary
- extend list of forbidden article names in `ReceiptParser`
- skip lines containing these names when parsing receipts

## Testing
- `./gradlew test` *(fails: Unable to download gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_685dc360ad188328afa7d38807cf1c26