### PR TITLE
Fix price advantage parsing

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -252,16 +252,7 @@ public class ReceiptParser {
             if (priceMatcher.matches()) {
                 double price = parseDouble(priceMatcher.group(1));
 
-                if (pendingName != null) {
-                    // Preis gehört zu pendingName → normaler Artikel
-                    lastItem = new PurchaseItem(pendingName, price);
-                    items.add(lastItem);
-                    Log.d("ReceiptParser", "Erkannt: Artikel: " + pendingName + " / Preis: " + price);
-                    pendingName = null;
-                    continue;
-                }
-
-                if (price < 0 && lastItem != null) {
+                if (price < 0 && pendingName == null && lastItem != null) {
                     // Preisvorteil zu vorherigem Artikel
                     double newPrice = lastItem.getPrice() + price;
                     if (newPrice < 0) {
@@ -273,6 +264,15 @@ public class ReceiptParser {
                         items.set(items.size() - 1, lastItem);
                         Log.d("ReceiptParser", "Preisvorteil angewendet: " + price + " → Neuer Preis: " + newPrice);
                     }
+                    continue;
+                }
+
+                if (pendingName != null) {
+                    // Preis gehört zu pendingName → normaler Artikel
+                    lastItem = new PurchaseItem(pendingName, price);
+                    items.add(lastItem);
+                    Log.d("ReceiptParser", "Erkannt: Artikel: " + pendingName + " / Preis: " + price);
+                    pendingName = null;
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary
- correctly handle discount-only lines by checking for a negative price when no pending item name exists
- move discount handling before normal article processing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dca41c4148328b33a5603af13d56e