### PR TITLE
Update regex for price-only pattern

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -60,7 +60,7 @@ public class ReceiptParser {
     private static final Pattern DISCOUNT_PATTERN =
             Pattern.compile("^\\-\\d+[.,]\\d{2}$");
     private static final Pattern PRICE_ONLY_PATTERN =
-            Pattern.compile("(-?\\d+[.,]\\d{2})\\s*(?:€|EUR)?\\s*[A-Z]?$");
+            Pattern.compile("^\\s*(-?\\d{1,3}(?:[.,]\\d{2}))\\s*(?:€|EUR)?\\s*[A-Z]?$");
     private static final Pattern PRICE_ELEMENT_PATTERN =
             Pattern.compile("-?\\d+[.,]\\d{2}A?");
     // Lines containing the following keywords should never be treated as item


### PR DESCRIPTION
## Summary
- refine `PRICE_ONLY_PATTERN` regex to allow leading whitespace and restrict number size

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dce784b84832894a3230fe01d957e