### PR TITLE
Fix price-only item names

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptParser.java
@@ -267,6 +267,11 @@ public class ReceiptParser {
             Matcher itemMatcher = ITEM_PATTERN.matcher(line);
             if (itemMatcher.matches()) {
                 String name = itemMatcher.group(1).trim();
+                // Verhindere Artikel wie "4,99 A"
+                if (name.matches("^\\d+[.,]\\d{2}(\\s*A)?$") ) {
+                    Log.d("ReceiptParser", "Zeile ignoriert: Name ist nur ein Preis: " + name);
+                    continue;
+                }
                 double price = parseDouble(itemMatcher.group(2));
                 lastItem = new PurchaseItem(name, price);
                 Log.d("ReceiptParser", "Erkannt: Artikel: " + name + " / Preis: " + price);


### PR DESCRIPTION
## Summary
- ignore lines that only contain a price when parsing receipts

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dd37e605c8328b26e60f5fa2f0f9a