### PR TITLE
Add Einkauf header

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -44,6 +44,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
     private TextView tvAddress;
     private TextView tvDate;
     private TextView tvTotal;
+    private TextView tvPurchaseHeader;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -76,6 +77,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
         tvAddress = findViewById(R.id.tvAddress);
         tvDate = findViewById(R.id.tvDate);
         tvTotal = findViewById(R.id.tvTotal);
+        tvPurchaseHeader = findViewById(R.id.tvPurchaseHeader);
 
         navPurchases = findViewById(R.id.navPurchases);
         navPeople = findViewById(R.id.navPeople);
@@ -114,6 +116,8 @@ public class NewPurchaseActivity extends AppCompatActivity {
         } else {
             itemRecycler.setVisibility(View.VISIBLE);
         }
+
+        tvPurchaseHeader.setVisibility(View.VISIBLE);
 
         tvResult.setText("");
 

--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -99,12 +99,25 @@
                 android:layout_marginTop="8dp"
                 android:layout_gravity="center_horizontal" />
 
+            <TextView
+                android:id="@+id/tvPurchaseHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="Einkauf"
+                android:textStyle="bold"
+                android:textSize="16sp"
+                android:visibility="gone" />
+
 
             <TextView
                 android:id="@+id/tvAddress"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
+                android:layout_marginTop="0dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:textColor="@color/black" />


### PR DESCRIPTION
## Summary
- show purchase header after uploading receipt
- update purchase screen layout spacing

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685dda113c108328b9bab9599ad6a413