### PR TITLE
Fix Artikel header alignment

### DIFF
--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -138,7 +138,8 @@
                 android:text="Artikelliste"
                 android:textSize="18sp"
                 android:textStyle="bold"
-                android:layout_marginBottom="8dp"/>
+                android:layout_marginBottom="8dp"
+                android:layout_marginStart="16dp"/>
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerItems"


### PR DESCRIPTION
## Summary
- align "Artikelliste" header with the "Personen:" label by using the same left margin

## Testing
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ddbba94208328a70d7f312bbc4416