### PR TITLE
Update purchase layout margins

### DIFF
--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -117,7 +117,7 @@
                 android:id="@+id/tvAddress"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="0dp"
+                android:layout_marginTop="8dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="16dp"
                 android:textColor="@color/black" />
@@ -138,6 +138,7 @@
                 android:text="Artikelliste"
                 android:textSize="18sp"
                 android:textStyle="bold"
+                android:layout_marginTop="24dp"
                 android:layout_marginBottom="8dp"
                 android:layout_marginStart="16dp"/>
 


### PR DESCRIPTION
## Summary
- increase top margin before address to 8dp
- add 24dp space above article list header

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ddd85d7b8832899546b5eadaab016