### PR TITLE
Implement invoice summary

### DIFF
--- a/app/src/main/res/layout/activity_new_purchase.xml
+++ b/app/src/main/res/layout/activity_new_purchase.xml
@@ -160,13 +160,6 @@
                 android:textStyle="bold"
                 android:textSize="20sp" />
 
-            <TextView
-                android:id="@+id/tvResult"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textColor="@color/black"
-                android:layout_margin="8dp" />
-
             <Button
                 android:id="@+id/btnCreateInvoice"
                 android:layout_width="wrap_content"
@@ -176,6 +169,30 @@
                 android:textColor="@color/white"
                 android:layout_marginTop="8dp"
                 android:layout_gravity="center_horizontal" />
+
+            <TextView
+                android:id="@+id/text_invoice_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/invoice_title"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:layout_marginStart="16dp"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="16dp"
+                android:visibility="gone" />
+
+            <TextView
+                android:id="@+id/tvResult"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/black"
+                android:textSize="16sp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="32dp"
+                android:visibility="gone" />
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="upload_receipt">Upload Kassenbon</string>
     <string name="checkbox_paid">bezahlt</string>
     <string name="create_invoice">Rechnung erstellen</string>
+    <string name="invoice_title">Rechnung</string>
+    <string name="error_choose_payer">Bitte wähle die zahlende Person aus.</string>
     <string name="error_assign_person">Bitte weise allen Artikeln mindestens eine Person zu.</string>
     <string name="dialog_select_persons_title">Personen auswählen</string>
     <string name="total_label">Gesamt: %1$.2f€</string>


### PR DESCRIPTION
## Summary
- show invoice header and list below 'Rechnung erstellen'
- compute per-person debts towards payer
- display formatted debt lines
- add strings for invoice and payer warning

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685de02342f0832889f1ef5dcd6f45b1