### PR TITLE
Format purchase date in list

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -142,7 +142,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
         invoicePaid = false;
 
         if (meta.getDateTime() != null) {
-            DateTimeFormatter df = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
+            DateTimeFormatter df = DateTimeFormatter.ofPattern("dd.MM.yyyy");
             purchaseDate = df.format(meta.getDateTime());
             tvDate.setText(purchaseDate);
         } else {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseAdapter.java
@@ -8,9 +8,13 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class PurchaseAdapter extends RecyclerView.Adapter<PurchaseAdapter.PurchaseViewHolder> {
+
+    private static final DateTimeFormatter OUTPUT_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
     private final List<Purchase> purchases;
 
@@ -28,7 +32,7 @@ public class PurchaseAdapter extends RecyclerView.Adapter<PurchaseAdapter.Purcha
     @Override
     public void onBindViewHolder(@NonNull PurchaseViewHolder holder, int position) {
         Purchase purchase = purchases.get(position);
-        holder.date.setText("Einkauf vom " + purchase.getDate());
+        holder.date.setText("Einkauf vom " + formatDate(purchase.getDate()));
         holder.amount.setText(purchase.getAmount());
         String statusText = purchase.isPaid() ? "Status: bezahlt" : "Status: offen";
         holder.status.setText(statusText);
@@ -50,5 +54,27 @@ public class PurchaseAdapter extends RecyclerView.Adapter<PurchaseAdapter.Purcha
             amount = itemView.findViewById(R.id.tvAmount);
             status = itemView.findViewById(R.id.tvStatus);
         }
+    }
+
+    private String formatDate(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return "";
+        }
+        try {
+            if (raw.contains("T")) {
+                LocalDate d = LocalDate.parse(raw.substring(0, 10));
+                return d.format(OUTPUT_FORMAT);
+            }
+            if (raw.matches("\\d{2}\\.\\d{2}\\.\\d{4}.*")) {
+                LocalDate d = LocalDate.parse(raw.substring(0, 10), OUTPUT_FORMAT);
+                return d.format(OUTPUT_FORMAT);
+            }
+            if (raw.matches("\\d{4}-\\d{2}-\\d{2}.*")) {
+                LocalDate d = LocalDate.parse(raw.substring(0, 10));
+                return d.format(OUTPUT_FORMAT);
+            }
+        } catch (Exception ignored) {
+        }
+        return raw;
     }
 }


### PR DESCRIPTION
## Summary
- store only the date when parsing new receipts
- format purchase date in adapter to hide time

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685de81d5b4083288a6cd51e61c44e2e