### PR TITLE
Enable editing and deleting purchases

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
             android:exported="true"
             android:theme="@style/Theme.LidlSplit" />
 
+        <activity
+            android:name=".EditPurchaseActivity"
+            android:exported="true"
+            android:theme="@style/Theme.LidlSplit" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
@@ -103,15 +103,44 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
         return db.insert(TABLE_PURCHASES, null, values);
     }
 
+    public int updatePurchase(long id, String date, double amount, boolean paid) {
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_PURCHASE_DATE, date);
+        values.put(COLUMN_PURCHASE_AMOUNT, amount);
+        values.put(COLUMN_PURCHASE_PAID, paid ? 1 : 0);
+        return db.update(TABLE_PURCHASES, values, "id=?", new String[]{String.valueOf(id)});
+    }
+
+    public int deletePurchase(long id) {
+        SQLiteDatabase db = getWritableDatabase();
+        return db.delete(TABLE_PURCHASES, "id=?", new String[]{String.valueOf(id)});
+    }
+
+    public Purchase getPurchase(long id) {
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.query(TABLE_PURCHASES, null, "id=?", new String[]{String.valueOf(id)}, null, null, null);
+        Purchase purchase = null;
+        if (cursor.moveToFirst()) {
+            String date = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_DATE));
+            double amount = cursor.getDouble(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_AMOUNT));
+            boolean paid = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_PAID)) == 1;
+            purchase = new Purchase(id, date, amount, paid);
+        }
+        cursor.close();
+        return purchase;
+    }
+
     public List<Purchase> getAllPurchases() {
         List<Purchase> purchases = new ArrayList<>();
         SQLiteDatabase db = getReadableDatabase();
         Cursor cursor = db.query(TABLE_PURCHASES, null, null, null, null, null, "id DESC");
         while (cursor.moveToNext()) {
+            long id = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_ID));
             String date = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_DATE));
             double amount = cursor.getDouble(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_AMOUNT));
             boolean paid = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_PAID)) == 1;
-            purchases.add(new Purchase(date, String.format(java.util.Locale.getDefault(), "%.2f€", amount), paid));
+            purchases.add(new Purchase(id, date, amount, paid));
         }
         cursor.close();
         return purchases;

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/EditPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/EditPurchaseActivity.java
@@ -1,0 +1,59 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class EditPurchaseActivity extends AppCompatActivity {
+
+    private AppDatabaseHelper dbHelper;
+    private long purchaseId;
+    private EditText etDate;
+    private EditText etAmount;
+    private CheckBox cbPaid;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_edit_purchase);
+
+        dbHelper = new AppDatabaseHelper(this);
+
+        etDate = findViewById(R.id.etDate);
+        etAmount = findViewById(R.id.etAmount);
+        cbPaid = findViewById(R.id.cbPaid);
+        Button save = findViewById(R.id.btnSavePurchase);
+
+        purchaseId = getIntent().getLongExtra("purchase_id", -1);
+        if (purchaseId != -1) {
+            Purchase purchase = dbHelper.getPurchase(purchaseId);
+            if (purchase != null) {
+                etDate.setText(purchase.getDate());
+                etAmount.setText(String.format(java.util.Locale.getDefault(), "%.2f", purchase.getAmount()));
+                cbPaid.setChecked(purchase.isPaid());
+            }
+        }
+
+        save.setOnClickListener(v -> saveChanges());
+    }
+
+    private void saveChanges() {
+        String date = etDate.getText().toString().trim();
+        String amountStr = etAmount.getText().toString().trim();
+        if (date.isEmpty() || amountStr.isEmpty()) {
+            Toast.makeText(this, "Bitte alle Felder ausfüllen", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        double amount = Double.parseDouble(amountStr.replace(',', '.'));
+        boolean paid = cbPaid.isChecked();
+
+        if (purchaseId == -1) return;
+        dbHelper.updatePurchase(purchaseId, date, amount, paid);
+        finish();
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
@@ -12,13 +12,15 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import java.util.List;
+
+import de.th.nuernberg.bme.lidlsplit.PurchaseAdapter;
 
 public class MainActivity extends AppCompatActivity {
 
     private TextView navPurchases;
     private TextView navPeople;
     private AppDatabaseHelper dbHelper;
+    private PurchaseAdapter adapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,8 +32,13 @@ public class MainActivity extends AppCompatActivity {
         // RecyclerView einrichten
         RecyclerView recyclerView = findViewById(R.id.recyclerPurchases);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        PurchaseAdapter adapter = new PurchaseAdapter(dbHelper.getAllPurchases());
+        PurchaseAdapter adapter = new PurchaseAdapter(dbHelper.getAllPurchases(), dbHelper, purchase -> {
+            Intent intent = new Intent(MainActivity.this, EditPurchaseActivity.class);
+            intent.putExtra("purchase_id", purchase.getId());
+            startActivity(intent);
+        });
         recyclerView.setAdapter(adapter);
+        this.adapter = adapter;
 
         // "+ Einkauf hinzufügen" Button
         Button addButton = findViewById(R.id.btnAddPurchase);
@@ -61,6 +68,14 @@ public class MainActivity extends AppCompatActivity {
             overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
             finish();
         });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (adapter != null) {
+            adapter.updateData(dbHelper.getAllPurchases());
+        }
     }
 
     private void activateTab(TextView active, TextView inactive) {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Purchase.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Purchase.java
@@ -1,21 +1,27 @@
 package de.th.nuernberg.bme.lidlsplit;
 
 public class Purchase {
+    private final long id;
     private final String date;
-    private final String amount;
+    private final double amount;
     private final boolean paid;
 
-    public Purchase(String date, String amount, boolean paid) {
+    public Purchase(long id, String date, double amount, boolean paid) {
+        this.id = id;
         this.date = date;
         this.amount = amount;
         this.paid = paid;
+    }
+
+    public long getId() {
+        return id;
     }
 
     public String getDate() {
         return date;
     }
 
-    public String getAmount() {
+    public double getAmount() {
         return amount;
     }
 

--- a/app/src/main/res/layout/activity_edit_purchase.xml
+++ b/app/src/main/res/layout/activity_edit_purchase.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/etDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Datum" />
+
+    <EditText
+        android:id="@+id/etAmount"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="numberDecimal"
+        android:hint="Betrag" />
+
+    <CheckBox
+        android:id="@+id/cbPaid"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/checkbox_paid" />
+
+    <Button
+        android:id="@+id/btnSavePurchase"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/save_changes" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_purchase.xml
+++ b/app/src/main/res/layout/item_purchase.xml
@@ -15,7 +15,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
 
             <TextView
                 android:id="@+id/tvDate"
@@ -32,6 +33,26 @@
                 android:textColor="@color/black"
                 android:textStyle="bold"
                 android:textSize="20sp" />
+
+            <ImageButton
+                android:id="@+id/btnEditPurchase"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/edit"
+                android:tint="@color/grayText"
+                android:layout_marginStart="8dp"
+                android:contentDescription="Bearbeiten" />
+
+            <ImageButton
+                android:id="@+id/btnDeletePurchase"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/delete"
+                android:tint="@color/grayText"
+                android:contentDescription="Löschen" />
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,7 @@
     <string name="total_label">Gesamt: %1$.2f€</string>
     <string name="invoice_settled">beglichen</string>
     <string name="save_invoice">Rechnung speichern</string>
+    <string name="confirm_delete_purchase">Möchtest du diesen Einkauf wirklich löschen?</string>
+    <string name="edit_purchase_title">Einkauf bearbeiten</string>
+    <string name="save_changes">Änderungen speichern</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow editing and deleting purchases from the list
- add purchase id to the model
- implement database helpers for updating/removing purchases
- add `EditPurchaseActivity` for simple purchase editing
- refresh list on resume

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685de9b404708328861b40ebaaaf4d2e