### PR TITLE
Add editable purchase details

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,11 @@
             android:exported="true"
             android:theme="@style/Theme.LidlSplit" />
 
+        <activity
+            android:name=".PurchaseDetailActivity"
+            android:exported="true"
+            android:theme="@style/Theme.LidlSplit" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/AppDatabaseHelper.java
@@ -8,11 +8,12 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class AppDatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "app.db";
-    private static final int DATABASE_VERSION = 2;
+    private static final int DATABASE_VERSION = 3;
 
     public static final String TABLE_PERSONS = "persons";
     public static final String COLUMN_ID = "id";
@@ -22,6 +23,14 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
     public static final String COLUMN_PURCHASE_DATE = "date";
     public static final String COLUMN_PURCHASE_AMOUNT = "amount";
     public static final String COLUMN_PURCHASE_PAID = "paid";
+    public static final String COLUMN_PURCHASE_PAYER = "payer_id";
+
+    public static final String TABLE_PURCHASE_PERSONS = "purchase_persons";
+    public static final String TABLE_ARTICLES = "articles";
+    public static final String COLUMN_ARTICLE_NAME = "name";
+    public static final String COLUMN_ARTICLE_PRICE = "price";
+    public static final String TABLE_ARTICLE_PERSONS = "article_persons";
+    public static final String TABLE_DEBTS = "debts";
 
     public AppDatabaseHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -38,14 +47,52 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
                 "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
                 COLUMN_PURCHASE_DATE + " TEXT NOT NULL, " +
                 COLUMN_PURCHASE_AMOUNT + " REAL NOT NULL, " +
-                COLUMN_PURCHASE_PAID + " INTEGER NOT NULL)";
+                COLUMN_PURCHASE_PAYER + " INTEGER, " +
+                COLUMN_PURCHASE_PAID + " INTEGER NOT NULL, " +
+                "FOREIGN KEY(" + COLUMN_PURCHASE_PAYER + ") REFERENCES " + TABLE_PERSONS + "(" + COLUMN_ID + "))";
         db.execSQL(createPurchases);
+
+        String createPurchasePersons = "CREATE TABLE " + TABLE_PURCHASE_PERSONS + " (" +
+                "purchase_id INTEGER NOT NULL, " +
+                "person_id INTEGER NOT NULL, " +
+                "FOREIGN KEY(purchase_id) REFERENCES " + TABLE_PURCHASES + "(id), " +
+                "FOREIGN KEY(person_id) REFERENCES " + TABLE_PERSONS + "(" + COLUMN_ID + "))";
+        db.execSQL(createPurchasePersons);
+
+        String createArticles = "CREATE TABLE " + TABLE_ARTICLES + " (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "purchase_id INTEGER NOT NULL, " +
+                COLUMN_ARTICLE_NAME + " TEXT NOT NULL, " +
+                COLUMN_ARTICLE_PRICE + " REAL NOT NULL, " +
+                "FOREIGN KEY(purchase_id) REFERENCES " + TABLE_PURCHASES + "(id))";
+        db.execSQL(createArticles);
+
+        String createArticlePersons = "CREATE TABLE " + TABLE_ARTICLE_PERSONS + " (" +
+                "article_id INTEGER NOT NULL, " +
+                "person_id INTEGER NOT NULL, " +
+                "FOREIGN KEY(article_id) REFERENCES " + TABLE_ARTICLES + "(id), " +
+                "FOREIGN KEY(person_id) REFERENCES " + TABLE_PERSONS + "(" + COLUMN_ID + "))";
+        db.execSQL(createArticlePersons);
+
+        String createDebts = "CREATE TABLE " + TABLE_DEBTS + " (" +
+                "purchase_id INTEGER NOT NULL, " +
+                "debtor_id INTEGER NOT NULL, " +
+                "creditor_id INTEGER NOT NULL, " +
+                "settled INTEGER NOT NULL, " +
+                "FOREIGN KEY(purchase_id) REFERENCES " + TABLE_PURCHASES + "(id), " +
+                "FOREIGN KEY(debtor_id) REFERENCES " + TABLE_PERSONS + "(" + COLUMN_ID + "), " +
+                "FOREIGN KEY(creditor_id) REFERENCES " + TABLE_PERSONS + "(" + COLUMN_ID + "))";
+        db.execSQL(createDebts);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_PERSONS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_DEBTS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_ARTICLE_PERSONS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_ARTICLES);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_PURCHASE_PERSONS);
         db.execSQL("DROP TABLE IF EXISTS " + TABLE_PURCHASES);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_PERSONS);
         onCreate(db);
     }
 
@@ -94,22 +141,137 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
         return db.delete(TABLE_PERSONS, COLUMN_ID + "=?", new String[]{String.valueOf(id)});
     }
 
-    public long addPurchase(String date, double amount, boolean paid) {
+    public long addPurchase(String date, double amount, long payerId,
+                            List<Person> persons,
+                            List<Article> articles,
+                            Map<Article, List<Person>> assignments,
+                            Map<DebtPair, Boolean> debts) {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(COLUMN_PURCHASE_DATE, date);
         values.put(COLUMN_PURCHASE_AMOUNT, amount);
-        values.put(COLUMN_PURCHASE_PAID, paid ? 1 : 0);
-        return db.insert(TABLE_PURCHASES, null, values);
+        values.put(COLUMN_PURCHASE_PAYER, payerId);
+        values.put(COLUMN_PURCHASE_PAID, 0);
+        long purchaseId = db.insert(TABLE_PURCHASES, null, values);
+
+        for (Person p : persons) {
+            ContentValues pv = new ContentValues();
+            pv.put("purchase_id", purchaseId);
+            pv.put("person_id", p.getId());
+            db.insert(TABLE_PURCHASE_PERSONS, null, pv);
+        }
+
+        Map<Article, Long> articleIds = new java.util.HashMap<>();
+        for (Article a : articles) {
+            ContentValues av = new ContentValues();
+            av.put("purchase_id", purchaseId);
+            av.put(COLUMN_ARTICLE_NAME, a.getName());
+            av.put(COLUMN_ARTICLE_PRICE, a.getPrice());
+            long aid = db.insert(TABLE_ARTICLES, null, av);
+            articleIds.put(a, aid);
+        }
+
+        if (assignments != null) {
+            for (Map.Entry<Article, List<Person>> e : assignments.entrySet()) {
+                Long aid = articleIds.get(e.getKey());
+                if (aid == null) continue;
+                for (Person p : e.getValue()) {
+                    ContentValues ap = new ContentValues();
+                    ap.put("article_id", aid);
+                    ap.put("person_id", p.getId());
+                    db.insert(TABLE_ARTICLE_PERSONS, null, ap);
+                }
+            }
+        }
+
+        if (debts != null) {
+            for (Map.Entry<DebtPair, Boolean> d : debts.entrySet()) {
+                ContentValues dv = new ContentValues();
+                dv.put("purchase_id", purchaseId);
+                dv.put("debtor_id", d.getKey().getDebtorId());
+                dv.put("creditor_id", d.getKey().getCreditorId());
+                dv.put("settled", d.getValue() ? 1 : 0);
+                db.insert(TABLE_DEBTS, null, dv);
+            }
+        }
+
+        updatePaidStatus(purchaseId);
+        return purchaseId;
     }
 
-    public int updatePurchase(long id, String date, double amount, boolean paid) {
+    private void updatePaidStatus(long purchaseId) {
+        SQLiteDatabase db = getWritableDatabase();
+        Cursor c = db.query(TABLE_DEBTS, new String[]{"settled"}, "purchase_id=?", new String[]{String.valueOf(purchaseId)}, null, null, null);
+        boolean paid = true;
+        while (c.moveToNext()) {
+            if (c.getInt(0) == 0) { paid = false; break; }
+        }
+        c.close();
+        ContentValues v = new ContentValues();
+        v.put(COLUMN_PURCHASE_PAID, paid ? 1 : 0);
+        db.update(TABLE_PURCHASES, v, "id=?", new String[]{String.valueOf(purchaseId)});
+    }
+
+    public int updatePurchase(long id, String date, double amount, long payerId,
+                              List<Person> persons,
+                              List<Article> articles,
+                              Map<Article, List<Person>> assignments,
+                              Map<DebtPair, Boolean> debts) {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues values = new ContentValues();
         values.put(COLUMN_PURCHASE_DATE, date);
         values.put(COLUMN_PURCHASE_AMOUNT, amount);
-        values.put(COLUMN_PURCHASE_PAID, paid ? 1 : 0);
-        return db.update(TABLE_PURCHASES, values, "id=?", new String[]{String.valueOf(id)});
+        values.put(COLUMN_PURCHASE_PAYER, payerId);
+        db.update(TABLE_PURCHASES, values, "id=?", new String[]{String.valueOf(id)});
+
+        db.delete(TABLE_PURCHASE_PERSONS, "purchase_id=?", new String[]{String.valueOf(id)});
+        db.delete(TABLE_ARTICLE_PERSONS, "article_id IN (SELECT id FROM " + TABLE_ARTICLES + " WHERE purchase_id=?)", new String[]{String.valueOf(id)});
+        db.delete(TABLE_ARTICLES, "purchase_id=?", new String[]{String.valueOf(id)});
+        db.delete(TABLE_DEBTS, "purchase_id=?", new String[]{String.valueOf(id)});
+
+        for (Person p : persons) {
+            ContentValues pv = new ContentValues();
+            pv.put("purchase_id", id);
+            pv.put("person_id", p.getId());
+            db.insert(TABLE_PURCHASE_PERSONS, null, pv);
+        }
+
+        Map<Article, Long> articleIds = new java.util.HashMap<>();
+        for (Article a : articles) {
+            ContentValues av = new ContentValues();
+            av.put("purchase_id", id);
+            av.put(COLUMN_ARTICLE_NAME, a.getName());
+            av.put(COLUMN_ARTICLE_PRICE, a.getPrice());
+            long aid = db.insert(TABLE_ARTICLES, null, av);
+            articleIds.put(a, aid);
+        }
+
+        if (assignments != null) {
+            for (Map.Entry<Article, List<Person>> e : assignments.entrySet()) {
+                Long aid = articleIds.get(e.getKey());
+                if (aid == null) continue;
+                for (Person p : e.getValue()) {
+                    ContentValues ap = new ContentValues();
+                    ap.put("article_id", aid);
+                    ap.put("person_id", p.getId());
+                    db.insert(TABLE_ARTICLE_PERSONS, null, ap);
+                }
+            }
+        }
+
+        if (debts != null) {
+            for (Map.Entry<DebtPair, Boolean> d : debts.entrySet()) {
+                ContentValues dv = new ContentValues();
+                dv.put("purchase_id", id);
+                dv.put("debtor_id", d.getKey().getDebtorId());
+                dv.put("creditor_id", d.getKey().getCreditorId());
+                dv.put("settled", d.getValue() ? 1 : 0);
+                db.insert(TABLE_DEBTS, null, dv);
+            }
+        }
+
+        updatePaidStatus(id);
+        return 1;
     }
 
     public int deletePurchase(long id) {
@@ -120,15 +282,64 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
     public Purchase getPurchase(long id) {
         SQLiteDatabase db = getReadableDatabase();
         Cursor cursor = db.query(TABLE_PURCHASES, null, "id=?", new String[]{String.valueOf(id)}, null, null, null);
-        Purchase purchase = null;
-        if (cursor.moveToFirst()) {
-            String date = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_DATE));
-            double amount = cursor.getDouble(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_AMOUNT));
-            boolean paid = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_PAID)) == 1;
-            purchase = new Purchase(id, date, amount, paid);
+        if (!cursor.moveToFirst()) {
+            cursor.close();
+            return null;
         }
+
+        String date = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_DATE));
+        double amount = cursor.getDouble(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_AMOUNT));
+        long payer = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_PAYER));
         cursor.close();
-        return purchase;
+
+        List<Person> persons = new ArrayList<>();
+        Cursor pc = db.rawQuery("SELECT p." + COLUMN_ID + ", p." + COLUMN_NAME + " FROM " + TABLE_PERSONS + " p JOIN " + TABLE_PURCHASE_PERSONS + " pp ON p." + COLUMN_ID + "=pp.person_id WHERE pp.purchase_id=?", new String[]{String.valueOf(id)});
+        while (pc.moveToNext()) {
+            persons.add(new Person(pc.getLong(0), pc.getString(1)));
+        }
+        pc.close();
+
+        List<Article> articles = new ArrayList<>();
+        Map<Long, Article> articleById = new java.util.HashMap<>();
+        Cursor ac = db.query(TABLE_ARTICLES, null, "purchase_id=?", new String[]{String.valueOf(id)}, null, null, null);
+        while (ac.moveToNext()) {
+            long aid = ac.getLong(ac.getColumnIndexOrThrow(COLUMN_ID));
+            String name = ac.getString(ac.getColumnIndexOrThrow(COLUMN_ARTICLE_NAME));
+            double price = ac.getDouble(ac.getColumnIndexOrThrow(COLUMN_ARTICLE_PRICE));
+            Article a = new Article(name, price);
+            articles.add(a);
+            articleById.put(aid, a);
+        }
+        ac.close();
+
+        Map<Article, List<Person>> assignments = new java.util.HashMap<>();
+        Cursor ap = db.query(TABLE_ARTICLE_PERSONS, null, "article_id IN (SELECT id FROM " + TABLE_ARTICLES + " WHERE purchase_id=?)", new String[]{String.valueOf(id)}, null, null, null);
+        while (ap.moveToNext()) {
+            long aid = ap.getLong(ap.getColumnIndexOrThrow("article_id"));
+            long pid = ap.getLong(ap.getColumnIndexOrThrow("person_id"));
+            Article art = articleById.get(aid);
+            if (art == null) continue;
+            Person person = null;
+            for (Person p : persons) if (p.getId() == pid) { person = p; break; }
+            if (person == null) continue;
+            assignments.computeIfAbsent(art, k -> new ArrayList<>()).add(person);
+        }
+        ap.close();
+
+        Map<DebtPair, Boolean> debts = new java.util.HashMap<>();
+        Cursor dc = db.query(TABLE_DEBTS, null, "purchase_id=?", new String[]{String.valueOf(id)}, null, null, null);
+        while (dc.moveToNext()) {
+            long debtor = dc.getLong(dc.getColumnIndexOrThrow("debtor_id"));
+            long creditor = dc.getLong(dc.getColumnIndexOrThrow("creditor_id"));
+            boolean settled = dc.getInt(dc.getColumnIndexOrThrow("settled")) == 1;
+            debts.put(new DebtPair(debtor, creditor), settled);
+        }
+        dc.close();
+
+        boolean paid = true;
+        for (Boolean b : debts.values()) { if (!b) { paid = false; break; } }
+
+        return new Purchase(id, date, amount, paid, payer, persons, articles, assignments, debts);
     }
 
     public List<Purchase> getAllPurchases() {
@@ -139,7 +350,14 @@ public class AppDatabaseHelper extends SQLiteOpenHelper {
             long id = cursor.getLong(cursor.getColumnIndexOrThrow(COLUMN_ID));
             String date = cursor.getString(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_DATE));
             double amount = cursor.getDouble(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_AMOUNT));
-            boolean paid = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_PURCHASE_PAID)) == 1;
+
+            Cursor dc = db.query(TABLE_DEBTS, new String[]{"settled"}, "purchase_id=?", new String[]{String.valueOf(id)}, null, null, null);
+            boolean paid = true;
+            while (dc.moveToNext()) {
+                if (dc.getInt(0) == 0) { paid = false; break; }
+            }
+            dc.close();
+
             purchases.add(new Purchase(id, date, amount, paid));
         }
         cursor.close();

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/DebtPair.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/DebtPair.java
@@ -1,0 +1,27 @@
+package de.th.nuernberg.bme.lidlsplit;
+
+public class DebtPair {
+    private final long debtorId;
+    private final long creditorId;
+
+    public DebtPair(long debtorId, long creditorId) {
+        this.debtorId = debtorId;
+        this.creditorId = creditorId;
+    }
+
+    public long getDebtorId() { return debtorId; }
+    public long getCreditorId() { return creditorId; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DebtPair other = (DebtPair) o;
+        return debtorId == other.debtorId && creditorId == other.creditorId;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(debtorId, creditorId);
+    }
+}

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/MainActivity.java
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 
 import de.th.nuernberg.bme.lidlsplit.PurchaseAdapter;
+import de.th.nuernberg.bme.lidlsplit.PurchaseDetailActivity;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -33,7 +34,7 @@ public class MainActivity extends AppCompatActivity {
         RecyclerView recyclerView = findViewById(R.id.recyclerPurchases);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         PurchaseAdapter adapter = new PurchaseAdapter(dbHelper.getAllPurchases(), dbHelper, purchase -> {
-            Intent intent = new Intent(MainActivity.this, EditPurchaseActivity.class);
+            Intent intent = new Intent(MainActivity.this, PurchaseDetailActivity.class);
             intent.putExtra("purchase_id", purchase.getId());
             startActivity(intent);
         });

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PersonSelectAdapter.java
@@ -35,6 +35,11 @@ public class PersonSelectAdapter extends RecyclerView.Adapter<PersonSelectAdapte
         return payerId;
     }
 
+    public void setPayerId(long id) {
+        this.payerId = id;
+        notifyDataSetChanged();
+    }
+
     @NonNull
     @Override
     public PersonSelectViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Purchase.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/Purchase.java
@@ -6,11 +6,31 @@ public class Purchase {
     private final double amount;
     private final boolean paid;
 
+    private long payerId;
+    private java.util.List<Person> persons;
+    private java.util.List<Article> articles;
+    private java.util.Map<Article, java.util.List<Person>> assignments;
+    private java.util.Map<DebtPair, Boolean> debtStatus;
+
     public Purchase(long id, String date, double amount, boolean paid) {
+        this(id, date, amount, paid, -1, new java.util.ArrayList<>(), new java.util.ArrayList<>(), new java.util.HashMap<>(), new java.util.HashMap<>());
+    }
+
+    public Purchase(long id, String date, double amount, boolean paid,
+                    long payerId,
+                    java.util.List<Person> persons,
+                    java.util.List<Article> articles,
+                    java.util.Map<Article, java.util.List<Person>> assignments,
+                    java.util.Map<DebtPair, Boolean> debtStatus) {
         this.id = id;
         this.date = date;
         this.amount = amount;
         this.paid = paid;
+        this.payerId = payerId;
+        this.persons = persons;
+        this.articles = articles;
+        this.assignments = assignments;
+        this.debtStatus = debtStatus;
     }
 
     public long getId() {
@@ -27,5 +47,25 @@ public class Purchase {
 
     public boolean isPaid() {
         return paid;
+    }
+
+    public long getPayerId() {
+        return payerId;
+    }
+
+    public java.util.List<Person> getPersons() {
+        return persons;
+    }
+
+    public java.util.List<Article> getArticles() {
+        return articles;
+    }
+
+    public java.util.Map<Article, java.util.List<Person>> getAssignments() {
+        return assignments;
+    }
+
+    public java.util.Map<DebtPair, Boolean> getDebtStatus() {
+        return debtStatus;
     }
 }

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
@@ -1,53 +1,51 @@
 package de.th.nuernberg.bme.lidlsplit;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
-import android.view.View;
-import android.util.Log;
 
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import de.th.nuernberg.bme.lidlsplit.ReceiptScanner;
-import de.th.nuernberg.bme.lidlsplit.Article;
-import de.th.nuernberg.bme.lidlsplit.DebtPair;
-
-
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class NewPurchaseActivity extends AppCompatActivity {
+import de.th.nuernberg.bme.lidlsplit.Article;
+import de.th.nuernberg.bme.lidlsplit.Debt;
+import de.th.nuernberg.bme.lidlsplit.DebtPair;
+import de.th.nuernberg.bme.lidlsplit.Person;
+import de.th.nuernberg.bme.lidlsplit.Purchase;
+import de.th.nuernberg.bme.lidlsplit.PurchaseItem;
+import de.th.nuernberg.bme.lidlsplit.PersonSelectAdapter;
+import de.th.nuernberg.bme.lidlsplit.ReceiptItemAdapter;
+import de.th.nuernberg.bme.lidlsplit.DebtAdapter;
+
+public class PurchaseDetailActivity extends AppCompatActivity {
 
     private AppDatabaseHelper dbHelper;
     private PersonSelectAdapter personAdapter;
     private ReceiptItemAdapter itemAdapter;
     private final List<Person> selectedPersons = new ArrayList<>();
-    private RecyclerView itemRecycler;
     private final List<PurchaseItem> items = new ArrayList<>();
-    private final ActivityResultLauncher<String> filePicker = registerForActivityResult(
-            new ActivityResultContracts.GetContent(), this::processImage);
-
-    private TextView navPurchases;
-    private TextView navPeople;
+    private RecyclerView itemRecycler;
     private RecyclerView invoiceRecycler;
     private DebtAdapter debtAdapter;
     private final List<Debt> debts = new ArrayList<>();
-    private Button btnSaveInvoice;
+    private Button btnSave;
     private String purchaseDate = "";
     private double purchaseTotal = 0.0;
-    private boolean invoicePaid = false;
+    private long purchaseId;
     private TextView tvInvoiceHeader;
     private TextView tvSettledLabel;
     private TextView tvPaidLabel;
@@ -59,9 +57,15 @@ public class NewPurchaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_new_purchase);
+        setContentView(R.layout.activity_purchase_detail);
 
         dbHelper = new AppDatabaseHelper(this);
+
+        purchaseId = getIntent().getLongExtra("purchase_id", -1);
+        if (purchaseId == -1) {
+            finish();
+            return;
+        }
 
         Button addPerson = findViewById(R.id.btnAddPersonSelect);
         addPerson.setOnClickListener(v -> showPersonSelectDialog());
@@ -75,9 +79,6 @@ public class NewPurchaseActivity extends AppCompatActivity {
         itemRecycler.setLayoutManager(new LinearLayoutManager(this));
         itemAdapter = new ReceiptItemAdapter(items, selectedPersons);
         itemRecycler.setAdapter(itemAdapter);
-
-        Button upload = findViewById(R.id.btnUploadReceipt);
-        upload.setOnClickListener(v -> filePicker.launch("image/*"));
 
         Button create = findViewById(R.id.btnCreateInvoice);
         create.setOnClickListener(v -> createInvoice());
@@ -93,14 +94,12 @@ public class NewPurchaseActivity extends AppCompatActivity {
         tvDate = findViewById(R.id.tvDate);
         tvTotal = findViewById(R.id.tvTotal);
         tvPurchaseHeader = findViewById(R.id.tvPurchaseHeader);
-        btnSaveInvoice = findViewById(R.id.btnSaveInvoice);
-        btnSaveInvoice.setOnClickListener(v -> saveInvoice());
-        btnSaveInvoice.setVisibility(View.GONE);
+        btnSave = findViewById(R.id.btnSaveInvoice);
+        btnSave.setOnClickListener(v -> saveChanges());
 
-        navPurchases = findViewById(R.id.navPurchases);
-        navPeople = findViewById(R.id.navPeople);
+        TextView navPurchases = findViewById(R.id.navPurchases);
+        TextView navPeople = findViewById(R.id.navPeople);
         activateTab(navPurchases, navPeople);
-
         navPurchases.setOnClickListener(v -> activateTab(navPurchases, navPeople));
         navPeople.setOnClickListener(v -> {
             activateTab(navPeople, navPurchases);
@@ -108,78 +107,67 @@ public class NewPurchaseActivity extends AppCompatActivity {
             overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left);
             finish();
         });
+
+        loadPurchase();
     }
 
-    private void processImage(Uri uri) {
-        if (uri == null) return;
-        ReceiptScanner.scanImage(this, uri, new ReceiptScanner.Callback() {
-            @Override
-            public void onSuccess(ReceiptData data, List<PurchaseItem> parsedItems) {
-                items.clear();
-                items.addAll(parsedItems);
-                itemAdapter.notifyDataSetChanged();
-                updateUi(data);
-            }
-
-            @Override
-            public void onError(Exception e) {
-                Toast.makeText(NewPurchaseActivity.this, "OCR failed", Toast.LENGTH_SHORT).show();
-            }
-        });
-    }
-
-    private void updateUi(ReceiptData meta) {
-        if (items.isEmpty()) {
-            itemRecycler.setVisibility(View.GONE);
-        } else {
-            itemRecycler.setVisibility(View.VISIBLE);
+    private void loadPurchase() {
+        Purchase purchase = dbHelper.getPurchase(purchaseId);
+        if (purchase == null) {
+            finish();
+            return;
         }
 
-        tvPurchaseHeader.setVisibility(View.VISIBLE);
-        tvInvoiceHeader.setVisibility(View.GONE);
-        tvSettledLabel.setVisibility(View.GONE);
+        purchaseDate = purchase.getDate();
+        purchaseTotal = purchase.getAmount();
+        tvDate.setText(purchaseDate);
+        tvTotal.setText(getString(R.string.total_label, purchaseTotal));
+        selectedPersons.clear();
+        selectedPersons.addAll(purchase.getPersons());
+        personAdapter.updateData(new ArrayList<>(selectedPersons));
+        personAdapter.setPayerId(purchase.getPayerId());
+
+        items.clear();
+        for (Article a : purchase.getArticles()) {
+            items.add(new PurchaseItem(a.getName(), a.getPrice()));
+        }
+        itemAdapter = new ReceiptItemAdapter(items, selectedPersons);
+        itemRecycler.setAdapter(itemAdapter);
+        Map<Integer, Set<Long>> map = new HashMap<>();
+        int idx = 0;
+        for (Article a : purchase.getArticles()) {
+            List<Person> ps = purchase.getAssignments().get(a);
+            if (ps == null) { idx++; continue; }
+            Set<Long> set = new java.util.HashSet<>();
+            for (Person p : ps) set.add(p.getId());
+            map.put(idx, set);
+            idx++;
+        }
+        itemAdapter.setAssignments(map);
+
+        Map<Long, Double> totals = itemAdapter.calculateTotals();
         debts.clear();
+        long payerId = purchase.getPayerId();
+        Person payer = null;
+        for (Person p : selectedPersons) if (p.getId() == payerId) payer = p;
+        if (payer == null && !selectedPersons.isEmpty()) payer = selectedPersons.get(0);
+        for (Person p : selectedPersons) {
+            if (p.getId() == payerId) continue;
+            double amount = totals.getOrDefault(p.getId(), 0.0);
+            Debt d = new Debt(p, payer, amount);
+            Boolean settled = purchase.getDebtStatus().get(new DebtPair(p.getId(), payerId));
+            if (settled != null) d.setSettled(settled);
+            debts.add(d);
+        }
         debtAdapter.notifyDataSetChanged();
-        invoiceRecycler.setVisibility(View.GONE);
-        btnSaveInvoice.setVisibility(View.GONE);
-        invoicePaid = false;
-
-        if (meta.getDateTime() != null) {
-            DateTimeFormatter df = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-            purchaseDate = df.format(meta.getDateTime());
-            tvDate.setText(purchaseDate);
-        } else {
-            tvDate.setText("");
-            purchaseDate = "";
-        }
-
-        StringBuilder addr = new StringBuilder();
-        if (meta.getStreet() != null) {
-            addr.append(meta.getStreet());
-        }
-        if (meta.getCity() != null) {
-            if (addr.length() > 0) addr.append("\n");
-            addr.append(meta.getCity());
-        }
-        tvAddress.setText(addr.toString());
-
-        if (meta.getTotal() != 0.0) {
-            purchaseTotal = meta.getTotal();
-            tvTotal.setText(getString(R.string.total_label, meta.getTotal()));
-        } else {
-            purchaseTotal = 0.0;
-            tvTotal.setText("");
-        }
+        updatePurchaseStatus();
     }
-
 
     private void createInvoice() {
         if (!itemAdapter.allItemsAssigned()) {
             Toast.makeText(this, getString(R.string.error_assign_person), Toast.LENGTH_LONG).show();
             return;
         }
-        itemAdapter.notifyDataSetChanged();
-        itemRecycler.setVisibility(View.VISIBLE);
 
         long payerId = personAdapter.getPayerId();
         if (payerId == -1) {
@@ -212,19 +200,15 @@ public class NewPurchaseActivity extends AppCompatActivity {
         tvSettledLabel.setVisibility(View.VISIBLE);
         invoiceRecycler.setVisibility(View.VISIBLE);
         updatePurchaseStatus();
-        btnSaveInvoice.setVisibility(View.VISIBLE);
+        btnSave.setVisibility(View.VISIBLE);
     }
 
     private void updatePurchaseStatus() {
         boolean allPaid = true;
         for (Debt d : debts) {
-            if (!d.isSettled()) {
-                allPaid = false;
-                break;
-            }
+            if (!d.isSettled()) { allPaid = false; break; }
         }
-        invoicePaid = allPaid;
-        Log.d("PurchaseStatus", allPaid ? "paid" : "open");
+        tvPaidLabel.setVisibility(allPaid ? View.VISIBLE : View.GONE);
     }
 
     private void activateTab(TextView active, TextView inactive) {
@@ -254,51 +238,35 @@ public class NewPurchaseActivity extends AppCompatActivity {
                 .setPositiveButton(R.string.action_save, (dialog, which) -> {
                     selectedPersons.clear();
                     for (int i = 0; i < persons.size(); i++) {
-                        if (checked[i]) {
-                            selectedPersons.add(persons.get(i));
-                        }
+                        if (checked[i]) selectedPersons.add(persons.get(i));
                     }
                     personAdapter.updateData(new ArrayList<>(selectedPersons));
                     itemAdapter = new ReceiptItemAdapter(items, selectedPersons);
                     itemRecycler.setAdapter(itemAdapter);
-                    if (selectedPersons.isEmpty()) {
-                        tvPaidLabel.setVisibility(View.GONE);
-                    } else {
-                        tvPaidLabel.setVisibility(View.VISIBLE);
-                    }
                 })
                 .show();
     }
 
-    private void saveInvoice() {
+    private void saveChanges() {
         if (purchaseDate.isEmpty() || purchaseTotal == 0.0) {
             Toast.makeText(this, "Keine Rechnung", Toast.LENGTH_SHORT).show();
             return;
         }
         List<Article> articles = new ArrayList<>();
-        for (PurchaseItem pi : items) {
-            articles.add(new Article(pi.getName(), pi.getPrice()));
-        }
-        Map<Integer, java.util.Set<Long>> assignIds = itemAdapter.getAssignments();
-        Map<Article, List<Person>> assignments = new java.util.HashMap<>();
+        for (PurchaseItem pi : items) articles.add(new Article(pi.getName(), pi.getPrice()));
+        Map<Integer, Set<Long>> assignIds = itemAdapter.getAssignments();
+        Map<Article, List<Person>> assignments = new HashMap<>();
         for (int i = 0; i < items.size(); i++) {
-            java.util.Set<Long> sel = assignIds.get(i);
+            Set<Long> sel = assignIds.get(i);
             if (sel == null) continue;
             Article art = articles.get(i);
-            List<Person> plist = new ArrayList<>();
-            for (Long pid : sel) {
-                for (Person p : selectedPersons) {
-                    if (p.getId() == pid) plist.add(p);
-                }
-            }
-            assignments.put(art, plist);
+            List<Person> ps = new ArrayList<>();
+            for (Long pid : sel) for (Person p : selectedPersons) if (p.getId() == pid) ps.add(p);
+            assignments.put(art, ps);
         }
-        Map<DebtPair, Boolean> debtMap = new java.util.HashMap<>();
-        for (Debt d : debts) {
-            debtMap.put(new DebtPair(d.getDebtor().getId(), d.getCreditor().getId()), d.isSettled());
-        }
-        dbHelper.addPurchase(purchaseDate, purchaseTotal, personAdapter.getPayerId(), selectedPersons, articles, assignments, debtMap);
-        startActivity(new Intent(this, MainActivity.class));
+        Map<DebtPair, Boolean> debtMap = new HashMap<>();
+        for (Debt d : debts) debtMap.put(new DebtPair(d.getDebtor().getId(), d.getCreditor().getId()), d.isSettled());
+        dbHelper.updatePurchase(purchaseId, purchaseDate, purchaseTotal, personAdapter.getPayerId(), selectedPersons, articles, assignments, debtMap);
         finish();
     }
 }

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptItemAdapter.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/ReceiptItemAdapter.java
@@ -31,6 +31,18 @@ public class ReceiptItemAdapter extends RecyclerView.Adapter<ReceiptItemAdapter.
         this.persons = persons;
     }
 
+    public Map<Integer, Set<Long>> getAssignments() {
+        return assignments;
+    }
+
+    public void setAssignments(Map<Integer, Set<Long>> newAssignments) {
+        assignments.clear();
+        if (newAssignments != null) {
+            assignments.putAll(newAssignments);
+        }
+        notifyDataSetChanged();
+    }
+
     public Map<Long, Double> calculateTotals() {
         Map<Long, Double> totals = new HashMap<>();
         for (int i = 0; i < items.size(); i++) {

--- a/app/src/main/res/layout/activity_purchase_detail.xml
+++ b/app/src/main/res/layout/activity_purchase_detail.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".PurchaseDetailActivity">
+
+    <LinearLayout
+        android:id="@+id/headerLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:background="@color/lidlBlue"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tvHeader"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/edit_purchase_title"
+            android:textColor="@color/white"
+            android:textStyle="bold"
+            android:textSize="24sp" />
+    </LinearLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scrollContent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:padding="0dp"
+        app:layout_constraintTop_toBottomOf="@id/headerLayout"
+        app:layout_constraintBottom_toTopOf="@id/customFooter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="8dp">
+
+                <TextView
+                    android:id="@+id/tvPersonLabel"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Personen:"
+                    android:textStyle="bold"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/tvPaidLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/checkbox_paid"
+                    android:textStyle="bold"
+                    android:textSize="16sp"
+                    android:visibility="gone" />
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/btnAddPersonSelect"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/add_person"
+                android:backgroundTint="@color/lidlBlue"
+                android:textColor="@color/white"
+                android:layout_marginTop="8dp"
+                android:layout_gravity="center_horizontal" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerPersonsSelect"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
+
+
+            <TextView
+                android:id="@+id/tvPurchaseHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="Einkauf"
+                android:textStyle="bold"
+                android:textSize="16sp"
+                android:visibility="gone" />
+
+
+            <TextView
+                android:id="@+id/tvAddress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="0dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/black" />
+
+            <TextView
+                android:id="@+id/tvDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@color/black" />
+
+            <TextView
+                android:id="@+id/text_artikel_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Artikelliste"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:layout_marginBottom="8dp"
+                android:layout_marginStart="16dp"/>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerItems"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:nestedScrollingEnabled="false" />
+
+            <TextView
+                android:id="@+id/tvTotal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="24dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:textColor="@android:color/black"
+                android:textStyle="bold"
+                android:textSize="20sp" />
+
+            <Button
+                android:id="@+id/btnCreateInvoice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/create_invoice"
+                android:backgroundTint="@color/lidlBlue"
+                android:textColor="@color/white"
+                android:layout_marginTop="8dp"
+                android:layout_gravity="center_horizontal" />
+
+            <LinearLayout
+                android:id="@+id/layoutInvoiceHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="8dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/text_invoice_header"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/invoice_title"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvSettledLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/invoice_settled"
+                    android:textColor="@color/grayText"
+                    android:textSize="16sp" />
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerInvoice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="32dp"
+                android:nestedScrollingEnabled="false"
+                android:visibility="gone" />
+
+            <Button
+                android:id="@+id/btnSaveInvoice"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/save_changes"
+                android:backgroundTint="@color/lidlBlue"
+                android:textColor="@color/white"
+                android:layout_gravity="center_horizontal"
+                android:visibility="gone" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <LinearLayout
+        android:id="@+id/customFooter"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/navPurchases"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Einkäufe"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:background="@color/tab_active"
+            android:clickable="true"
+            android:focusable="true" />
+
+        <TextView
+            android:id="@+id/navPeople"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Personen"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            android:background="@color/tab_inactive"
+            android:clickable="true"
+            android:focusable="true" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- extend Purchase model with persons, articles, assignments, payer and debt status
- store full purchase information in SQLite database
- compute paid status from stored debts
- add detail activity using creation UI for editing purchases
- add layout and manifest entry for new detail screen

## Testing
- `./gradlew test` *(fails: HTTP 403 due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685dee1b9fd8832898ec1bcce32549a7