### PR TITLE
Add auto scroll after invoice creation

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -14,6 +14,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -55,6 +56,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
     private TextView tvDate;
     private TextView tvTotal;
     private TextView tvPurchaseHeader;
+    private NestedScrollView scrollView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -93,6 +95,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
         tvDate = findViewById(R.id.tvDate);
         tvTotal = findViewById(R.id.tvTotal);
         tvPurchaseHeader = findViewById(R.id.tvPurchaseHeader);
+        scrollView = findViewById(R.id.scrollContent);
         btnSaveInvoice = findViewById(R.id.btnSaveInvoice);
         btnSaveInvoice.setOnClickListener(v -> saveInvoice());
         btnSaveInvoice.setVisibility(View.GONE);
@@ -213,6 +216,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
         invoiceRecycler.setVisibility(View.VISIBLE);
         updatePurchaseStatus();
         btnSaveInvoice.setVisibility(View.VISIBLE);
+        scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
     }
 
     private void updatePurchaseStatus() {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
@@ -10,6 +10,7 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.core.widget.NestedScrollView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -53,6 +54,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
     private TextView tvDate;
     private TextView tvTotal;
     private TextView tvPurchaseHeader;
+    private NestedScrollView scrollView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -94,6 +96,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
         tvDate = findViewById(R.id.tvDate);
         tvTotal = findViewById(R.id.tvTotal);
         tvPurchaseHeader = findViewById(R.id.tvPurchaseHeader);
+        scrollView = findViewById(R.id.scrollContent);
         btnSave = findViewById(R.id.btnSaveInvoice);
         btnSave.setOnClickListener(v -> saveChanges());
 
@@ -201,6 +204,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
         invoiceRecycler.setVisibility(View.VISIBLE);
         updatePurchaseStatus();
         btnSave.setVisibility(View.VISIBLE);
+        scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
     }
 
     private void updatePurchaseStatus() {


### PR DESCRIPTION
## Summary
- ensure invoice view is visible in `NewPurchaseActivity` and `PurchaseDetailActivity`
- scroll to the bottom of the page once the invoice section appears

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e5d90a93c83289f8a9b85be28cef7