### PR TITLE
Scroll invoice into view after creation

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/NewPurchaseActivity.java
@@ -8,6 +8,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.view.View;
 import android.util.Log;
+import androidx.core.widget.NestedScrollView;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -55,11 +56,14 @@ public class NewPurchaseActivity extends AppCompatActivity {
     private TextView tvDate;
     private TextView tvTotal;
     private TextView tvPurchaseHeader;
+    private NestedScrollView scrollView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_purchase);
+
+        scrollView = findViewById(R.id.scrollContent);
 
         dbHelper = new AppDatabaseHelper(this);
 
@@ -213,6 +217,7 @@ public class NewPurchaseActivity extends AppCompatActivity {
         invoiceRecycler.setVisibility(View.VISIBLE);
         updatePurchaseStatus();
         btnSaveInvoice.setVisibility(View.VISIBLE);
+        scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
     }
 
     private void updatePurchaseStatus() {

--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.core.widget.NestedScrollView;
 
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -53,11 +54,14 @@ public class PurchaseDetailActivity extends AppCompatActivity {
     private TextView tvDate;
     private TextView tvTotal;
     private TextView tvPurchaseHeader;
+    private NestedScrollView scrollView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_purchase_detail);
+
+        scrollView = findViewById(R.id.scrollContent);
 
         dbHelper = new AppDatabaseHelper(this);
 
@@ -201,6 +205,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
         invoiceRecycler.setVisibility(View.VISIBLE);
         updatePurchaseStatus();
         btnSave.setVisibility(View.VISIBLE);
+        scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
     }
 
     private void updatePurchaseStatus() {


### PR DESCRIPTION
## Summary
- make the scroll view accessible in `NewPurchaseActivity` and `PurchaseDetailActivity`
- scroll to the bottom after revealing invoice section

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e63ed06848328a091bb5595aa3f21