### PR TITLE
Display payer label on purchase detail

### DIFF
--- a/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
+++ b/app/src/main/java/de/th/nuernberg/bme/lidlsplit/PurchaseDetailActivity.java
@@ -169,7 +169,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
         debtAdapter.notifyDataSetChanged();
         layoutInvoiceHeader.setVisibility(View.VISIBLE);
         invoiceRecycler.setVisibility(View.VISIBLE);
-        updatePurchaseStatus();
+        updatePaidLabelVisibility();
     }
 
     private void createInvoice() {
@@ -207,17 +207,21 @@ public class PurchaseDetailActivity extends AppCompatActivity {
 
         layoutInvoiceHeader.setVisibility(View.VISIBLE);
         invoiceRecycler.setVisibility(View.VISIBLE);
-        updatePurchaseStatus();
+        updatePaidLabelVisibility();
         btnSave.setVisibility(View.VISIBLE);
         scrollView.post(() -> scrollView.fullScroll(View.FOCUS_DOWN));
     }
 
     private void updatePurchaseStatus() {
-        boolean allPaid = true;
-        for (Debt d : debts) {
-            if (!d.isSettled()) { allPaid = false; break; }
+        // callback required by DebtAdapter, currently no additional status handling
+    }
+
+    private void updatePaidLabelVisibility() {
+        if (selectedPersons.isEmpty()) {
+            tvPaidLabel.setVisibility(View.GONE);
+        } else {
+            tvPaidLabel.setVisibility(View.VISIBLE);
         }
-        tvPaidLabel.setVisibility(allPaid ? View.VISIBLE : View.GONE);
     }
 
     private void activateTab(TextView active, TextView inactive) {
@@ -252,6 +256,7 @@ public class PurchaseDetailActivity extends AppCompatActivity {
                     personAdapter.updateData(new ArrayList<>(selectedPersons));
                     itemAdapter = new ReceiptItemAdapter(items, selectedPersons);
                     itemRecycler.setAdapter(itemAdapter);
+                    updatePaidLabelVisibility();
                 })
                 .show();
     }


### PR DESCRIPTION
## Summary
- show the "bezahlt" label in purchase details when persons are present
- adjust dialogs to refresh label visibility
- simplify purchase status update callback

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug -x lint -xtest` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e6ac8c46c8328b6f94abd5aa7a625